### PR TITLE
Frontend: improve performance initial commit

### DIFF
--- a/packages/frontend/src/components/device/DeviceList.tsx
+++ b/packages/frontend/src/components/device/DeviceList.tsx
@@ -18,8 +18,6 @@ import Typography from "@mui/material/Typography";
 
 export interface DeviceListProps {
   readonly devices: DeviceData[];
-  readonly timer?: number;
-  readonly onRefresh?: () => void;
 }
 
 export const DeviceList = ({ devices }: DeviceListProps) => {

--- a/packages/frontend/src/components/device/DeviceList.tsx
+++ b/packages/frontend/src/components/device/DeviceList.tsx
@@ -1,6 +1,5 @@
 import { DeviceData } from "@home-assistant-matter-hub/common";
 import {
-  Chip,
   List,
   ListItem,
   Stack,
@@ -23,7 +22,7 @@ export interface DeviceListProps {
   readonly onRefresh?: () => void;
 }
 
-export const DeviceList = ({ devices, timer, onRefresh }: DeviceListProps) => {
+export const DeviceList = ({ devices }: DeviceListProps) => {
   const sortedDevices = useMemo(
     () => [...devices].sort((a, b) => a.entityId.localeCompare(b.entityId)),
     [devices],
@@ -36,14 +35,7 @@ export const DeviceList = ({ devices, timer, onRefresh }: DeviceListProps) => {
             <TableCell size="small">Entity ID</TableCell>
             <TableCell>Name</TableCell>
             <TableCell>Endpoint</TableCell>
-            <TableCell>
-              <Box display="flex" justifyContent="space-between">
-                <div>State</div>
-                {timer != null && (
-                  <Chip onClick={onRefresh} label={(timer / 1000).toFixed(1)} />
-                )}
-              </Box>
-            </TableCell>
+            <TableCell>State</TableCell>
           </TableRow>
         </TableHead>
         <TableBody>

--- a/packages/frontend/src/hooks/timer.ts
+++ b/packages/frontend/src/hooks/timer.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 
-const resolutionMs = 100;
+const resolutionMs = 1000;
 
 export interface Timer {
   reset: () => void;

--- a/packages/frontend/src/pages/bridge-details/BridgeDetailsPage.tsx
+++ b/packages/frontend/src/pages/bridge-details/BridgeDetailsPage.tsx
@@ -1,14 +1,17 @@
 import { BridgeDetails } from "../../components/bridge/BridgeDetails.tsx";
 import { Link, useParams } from "react-router-dom";
 import { useBridge } from "../../hooks/data/bridges.ts";
-import { useCallback, useEffect, useState } from "react";
+import { memo, useCallback, useEffect, useState } from "react";
 import { useNotifications } from "@toolpad/core";
 import { useDevices } from "../../hooks/data/devices.ts";
 import { DeviceList } from "../../components/device/DeviceList.tsx";
 import { useTimer } from "../../hooks/timer.ts";
 import { IconButton, Stack, Typography } from "@mui/material";
 import Box from "@mui/material/Box";
-import { Edit } from "@mui/icons-material";
+import { Edit, Refresh } from "@mui/icons-material";
+
+const MemoizedBridgeDetails = memo(BridgeDetails);
+const MemoizedDeviceList = memo(DeviceList);
 
 export const BridgeDetailsPage = () => {
   const [seed, setSeed] = useState<number>(0);
@@ -28,7 +31,7 @@ export const BridgeDetailsPage = () => {
     sleepSeconds: 9,
     startImmediate: true,
     callback: useCallback(() => setSeed(Date.now()), [setSeed]),
-    onTick: setTimer,
+    onTick: useCallback(setTimer, []),
   });
 
   useEffect(() => {
@@ -60,11 +63,25 @@ export const BridgeDetailsPage = () => {
         </IconButton>
       </Box>
 
-      <BridgeDetails bridge={bridge} />
+      <MemoizedBridgeDetails bridge={bridge} />
 
-      {devices && (
-        <DeviceList devices={devices} timer={timer} onRefresh={refreshNow} />
-      )}
+      <Stack spacing={2}>
+        <Box display="flex" justifyContent="flex-start" alignItems="center">
+          <Typography variant="h6">Devices</Typography>
+          <IconButton onClick={refreshNow}>
+            <Refresh />
+          </IconButton>
+          {timer != null && (
+            <Typography variant="body2" color="textSecondary">
+              Auto-refresh in {(timer / 1000).toFixed(0)} seconds...
+            </Typography>
+          )}
+        </Box>
+
+        {devices && (
+          <MemoizedDeviceList devices={devices} onRefresh={refreshNow} />
+        )}
+      </Stack>
     </Stack>
   );
 };

--- a/packages/frontend/src/pages/bridge-details/BridgeDetailsPage.tsx
+++ b/packages/frontend/src/pages/bridge-details/BridgeDetailsPage.tsx
@@ -31,7 +31,7 @@ export const BridgeDetailsPage = () => {
     sleepSeconds: 9,
     startImmediate: true,
     callback: useCallback(() => setSeed(Date.now()), [setSeed]),
-    onTick: useCallback(setTimer, []),
+    onTick: setTimer,
   });
 
   useEffect(() => {
@@ -78,9 +78,7 @@ export const BridgeDetailsPage = () => {
           )}
         </Box>
 
-        {devices && (
-          <MemoizedDeviceList devices={devices} onRefresh={refreshNow} />
-        )}
+        {devices && <MemoizedDeviceList devices={devices} />}
       </Stack>
     </Stack>
   );

--- a/packages/frontend/src/pages/bridges/BridgesPage.tsx
+++ b/packages/frontend/src/pages/bridges/BridgesPage.tsx
@@ -37,7 +37,7 @@ export const BridgesPage = () => {
         sx={(theme) => ({ zIndex: theme.zIndex.drawer + 1 })}
         open={isLoading}
       >
-        <CircularProgress color="inherit" />
+        {isLoading && <CircularProgress color="inherit" />}
       </Backdrop>
 
       <Stack spacing={4}>


### PR DESCRIPTION
Made small changes to enhance frontend performance. High CPU usage was primarily caused by re-rendering the entire device list every 100ms.