### PR TITLE
fix: only hash labels larger than max length

### DIFF
--- a/packages/backend/src/matter/behaviors/basic-information-server.ts
+++ b/packages/backend/src/matter/behaviors/basic-information-server.ts
@@ -36,7 +36,7 @@ function maxLengthOrHash(value: string, maxLength: number): string {
   if (maxLength < 16) {
     throw new Error("MaxLength cannot be shorter than 16");
   }
-  if (value.length < maxLength) {
+  if (value.length <= maxLength) {
     return value;
   } else {
     const hash = crypto


### PR DESCRIPTION
This is a tiny fix for the fix for #116 so that labels that are equal to maxlength are not hashed but used unmodified.