### PR TITLE
Adding margin qr-code

### DIFF
--- a/packages/frontend/src/components/bridge/BridgeDetails.tsx
+++ b/packages/frontend/src/components/bridge/BridgeDetails.tsx
@@ -78,12 +78,12 @@ const Pairing = (props: { bridge: BridgeData }) => {
             </Alert>
           </Box>
         )}
-        <div style={{ background: 'white', padding: '9px', paddingBottom: "2.6px" }}>
+        <Box style={{ background: 'white', padding: '9px', paddingBottom: "2.6px" }}>
           <QRCode
             value={props.bridge.commissioning.qrPairingCode}
             style={{ width: "100%", height: "100%" }}
           />
-        </div>
+        </Box>
       </Box>
     </Box>
   );

--- a/packages/frontend/src/components/bridge/BridgeDetails.tsx
+++ b/packages/frontend/src/components/bridge/BridgeDetails.tsx
@@ -78,7 +78,13 @@ const Pairing = (props: { bridge: BridgeData }) => {
             </Alert>
           </Box>
         )}
-        <Box style={{ background: 'white', padding: '9px', paddingBottom: "2.6px" }}>
+        <Box
+          style={{
+            background: "white",
+            padding: "9px",
+            paddingBottom: "2.6px",
+          }}
+        >
           <QRCode
             value={props.bridge.commissioning.qrPairingCode}
             style={{ width: "100%", height: "100%" }}

--- a/packages/frontend/src/components/bridge/BridgeDetails.tsx
+++ b/packages/frontend/src/components/bridge/BridgeDetails.tsx
@@ -78,10 +78,12 @@ const Pairing = (props: { bridge: BridgeData }) => {
             </Alert>
           </Box>
         )}
-        <QRCode
-          value={props.bridge.commissioning.qrPairingCode}
-          style={{ width: "100%", height: "100%" }}
-        />
+        <div style={{ background: 'white', padding: '9px', paddingBottom: "2.6px" }}>
+          <QRCode
+            value={props.bridge.commissioning.qrPairingCode}
+            style={{ width: "100%", height: "100%" }}
+          />
+        </div>
       </Box>
     </Box>
   );


### PR DESCRIPTION
When scanning the QR code using the Google Home app, it struggles to read the code. After reviewing the library you've used, it recommends adding a white margin if you have a dark background color, as shown in the following image:
![image](https://github.com/user-attachments/assets/2056835e-8623-42b5-853d-ccc957fcce1d)

I've made the change so the margins fit well, as shown below.
![image](https://github.com/user-attachments/assets/bf00b3b5-99b3-4635-875a-555d70997c6b)

By the way, I've been testing a modified icon. If you like the idea, let me know and I can provide it for you to add to the app :)
![HAMH](https://github.com/user-attachments/assets/260ddf98-0d93-4cc6-ac0a-016a705cd090)

