### PR TITLE
bridge: Lock entity actions and updates

### DIFF
--- a/apps/home-assistant-matter-hub/package.json
+++ b/apps/home-assistant-matter-hub/package.json
@@ -53,6 +53,7 @@
     "@matter/main": "0.11.6",
     "@matter/nodejs": "0.11.6",
     "ajv": "8.17.1",
+    "async-lock": "1.4.1",
     "chalk": "5.3.0",
     "color": "4.2.3",
     "express": "5.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
         "@matter/main": "0.11.6",
         "@matter/nodejs": "0.11.6",
         "ajv": "8.17.1",
+        "async-lock": "1.4.1",
         "chalk": "5.3.0",
         "color": "4.2.3",
         "express": "5.0.1",
@@ -5412,6 +5413,13 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/async-lock": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@types/async-lock/-/async-lock-1.4.2.tgz",
+      "integrity": "sha512-HlZ6Dcr205BmNhwkdXqrg2vkFMN2PluI7Lgr8In3B3wE5PiQHhjRqtW/lGdVU9gw+sM0JcIDx2AN+cW8oSWIcw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -6492,6 +6500,12 @@
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
       "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT"
+    },
+    "node_modules/async-lock": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.4.1.tgz",
+      "integrity": "sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==",
       "license": "MIT"
     },
     "node_modules/asynckit": {
@@ -15454,6 +15468,7 @@
         "@matter/main": "0.11.6",
         "@matter/nodejs": "0.11.6",
         "ajv": "8.17.1",
+        "async-lock": "1.4.1",
         "chalk": "5.3.0",
         "express": "5.0.1",
         "home-assistant-js-websocket": "9.4.0",
@@ -15465,6 +15480,7 @@
         "yargs": "17.7.2"
       },
       "devDependencies": {
+        "@types/async-lock": "^1.4.2",
         "@types/express": "^5.0.0",
         "@types/lodash": "^4.17.13",
         "@types/strip-color": "^0.1.2",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -18,6 +18,7 @@
     "@matter/main": "0.11.6",
     "@matter/nodejs": "0.11.6",
     "ajv": "8.17.1",
+    "async-lock": "1.4.1",
     "chalk": "5.3.0",
     "express": "5.0.1",
     "home-assistant-js-websocket": "9.4.0",
@@ -29,6 +30,7 @@
     "ws": "8.18.0"
   },
   "devDependencies": {
+    "@types/async-lock": "^1.4.2",
     "@types/express": "^5.0.0",
     "@types/lodash": "^4.17.13",
     "@types/strip-color": "^0.1.2",

--- a/packages/backend/src/commands/start/start-handler.ts
+++ b/packages/backend/src/commands/start/start-handler.ts
@@ -8,6 +8,7 @@ import { createEnvironment } from "../../environment/environment.js";
 import { HomeAssistantClient } from "../../home-assistant/home-assistant-client.js";
 import { BridgeService } from "../../matter/bridge-service.js";
 import { WebApi } from "../../api/web-api.js";
+import AsyncLock from "async-lock";
 
 const basicInformation: BridgeBasicInformation = {
   vendorId: VendorId(0xfff1),
@@ -32,6 +33,7 @@ export async function startHandler(
     mdnsNetworkInterface: options.mdnsNetworkInterface,
     storageLocation: options.storageLocation,
   });
+  environment.set(AsyncLock, new AsyncLock());
 
   new HomeAssistantClient(environment, {
     url: options.homeAssistantUrl,

--- a/packages/backend/src/matter/bridge/bridge-device-manager.ts
+++ b/packages/backend/src/matter/bridge/bridge-device-manager.ts
@@ -86,9 +86,11 @@ export class BridgeDeviceManager {
 
   private async updateEntities(updates: Dictionary<HomeAssistantEntityState>) {
     const states = _.values(updates);
+    const results = [];
     for (const state of states) {
-      await this.updateEntity(state);
+      results.push(this.updateEntity(state));
     }
+    await Promise.all(results);
   }
 
   private async updateEntity(state: HomeAssistantEntityState) {

--- a/packages/backend/src/matter/bridge/bridge-device-manager.ts
+++ b/packages/backend/src/matter/bridge/bridge-device-manager.ts
@@ -97,13 +97,16 @@ export class BridgeDeviceManager {
     if (!device) {
       return;
     }
-    const { entity } = device.stateOf(HomeAssistantEntityBehavior);
+    const { entity, mutex } = device.stateOf(HomeAssistantEntityBehavior);
     const hasChanged = JSON.stringify(entity.state) !== JSON.stringify(state);
     if (!hasChanged) {
       return;
     }
-    await device.setStateOf(HomeAssistantEntityBehavior, {
-      entity: { ...entity, state },
+
+    await mutex.guard(async () => {
+      await device.setStateOf(HomeAssistantEntityBehavior, {
+        entity: { ...entity, state },
+      });
     });
   }
 

--- a/packages/backend/src/matter/bridge/bridge-device-manager.ts
+++ b/packages/backend/src/matter/bridge/bridge-device-manager.ts
@@ -9,6 +9,7 @@ import { HomeAssistantEntityBehavior } from "../custom-behaviors/home-assistant-
 import { HomeAssistantRegistry } from "../../home-assistant/home-assistant-registry.js";
 import _, { Dictionary } from "lodash";
 import { matchesEntityFilter } from "./matcher/matches-entity-filter.js";
+import AsyncLock from "async-lock";
 
 export class BridgeDeviceManager {
   private initialized = false;
@@ -73,7 +74,11 @@ export class BridgeDeviceManager {
       return false;
     }
     const endpointId = this.deviceId(entity.entity_id);
-    const endpointType = createDevice(entity, bridge.featureFlags);
+    const endpointType = createDevice(
+      lockKey(entity),
+      entity,
+      bridge.featureFlags,
+    );
     if (endpointType) {
       const endpoint = new Endpoint(endpointType, {
         id: endpointId,
@@ -86,11 +91,8 @@ export class BridgeDeviceManager {
 
   private async updateEntities(updates: Dictionary<HomeAssistantEntityState>) {
     const states = _.values(updates);
-    const results = [];
-    for (const state of states) {
-      results.push(this.updateEntity(state));
-    }
-    await Promise.all(results);
+    const handles = states.map((state) => this.updateEntity(state));
+    await Promise.all(handles);
   }
 
   private async updateEntity(state: HomeAssistantEntityState) {
@@ -99,13 +101,14 @@ export class BridgeDeviceManager {
     if (!device) {
       return;
     }
-    const { entity, mutex } = device.stateOf(HomeAssistantEntityBehavior);
+    const { entity } = device.stateOf(HomeAssistantEntityBehavior);
     const hasChanged = JSON.stringify(entity.state) !== JSON.stringify(state);
     if (!hasChanged) {
       return;
     }
 
-    await mutex.guard(async () => {
+    const lock = this.environment.get(AsyncLock);
+    await lock.acquire(lockKey(entity), async () => {
       await device.setStateOf(HomeAssistantEntityBehavior, {
         entity: { ...entity, state },
       });
@@ -121,4 +124,8 @@ function isValidEntity(entity: HomeAssistantEntityInformation): boolean {
   return (
     entity.registry?.disabled_by == null && entity.registry?.hidden_by == null
   );
+}
+
+function lockKey(entity: { entity_id: string }): string {
+  return entity.entity_id;
 }

--- a/packages/backend/src/matter/bridge/create-device.test.ts
+++ b/packages/backend/src/matter/bridge/create-device.test.ts
@@ -128,7 +128,7 @@ describe("createDevice", () => {
   it("should not use any unknown clusterId", () => {
     const entities = Object.values(testEntities).flat();
     const devices = entities.map((entity) =>
-      createDevice(entity, featureFlags),
+      createDevice("lock_" + entity.entity_id, entity, featureFlags),
     );
     const actual = _.uniq(
       devices

--- a/packages/backend/src/matter/bridge/create-device.ts
+++ b/packages/backend/src/matter/bridge/create-device.ts
@@ -17,6 +17,7 @@ import { HumidifierDevice } from "../devices/humidifier-device.js";
 import { EndpointType } from "@matter/main";
 
 export function createDevice(
+  lockKey: string,
   entity: HomeAssistantEntityInformation,
   featureFlags?: BridgeFeatureFlags,
 ): EndpointType | undefined {
@@ -25,7 +26,7 @@ export function createDevice(
   if (!factory) {
     return undefined;
   }
-  return factory({ entity }, featureFlags);
+  return factory({ entity, lockKey }, featureFlags);
 }
 
 const deviceCtrs: Record<

--- a/packages/backend/src/matter/custom-behaviors/home-assistant-entity-behavior.ts
+++ b/packages/backend/src/matter/custom-behaviors/home-assistant-entity-behavior.ts
@@ -7,6 +7,31 @@ import type { HassServiceTarget } from "home-assistant-js-websocket/dist/types.j
 import { AsyncObservable } from "../../utils/async-observable.js";
 import { HomeAssistantActions } from "../../home-assistant/home-assistant-actions.js";
 
+export class Mutex {
+  private mutex = Promise.resolve();
+
+  private async lock(): Promise<() => void> {
+    let begin: (unlock: () => void) => void = (unlock) => {};
+
+    this.mutex = this.mutex.then(() => {
+      return new Promise(begin);
+    });
+
+    return new Promise<() => void>((res) => {
+      begin = res;
+    });
+  }
+
+  async guard<T>(fn: () => Promise<T>): Promise<T> {
+    const unlock = await this.lock();
+    try {
+      return await fn();
+    } finally {
+      unlock();
+    }
+  }
+}
+
 export class HomeAssistantEntityBehavior extends Behavior {
   static override readonly id = ClusterId.homeAssistantEntity;
   declare state: HomeAssistantEntityBehavior.State;
@@ -31,13 +56,16 @@ export class HomeAssistantEntityBehavior extends Behavior {
     target: HassServiceTarget,
     returnResponse?: boolean,
   ): Promise<T> {
-    const actions = this.env.get(HomeAssistantActions);
-    return actions.callAction(domain, action, data, target, returnResponse);
+    return this.state.mutex.guard(() => {
+      const actions = this.env.get(HomeAssistantActions);
+      return actions.callAction(domain, action, data, target, returnResponse);
+    })
   }
 }
 
 export namespace HomeAssistantEntityBehavior {
   export class State {
+    mutex!: Mutex
     entity!: HomeAssistantEntityInformation;
   }
 


### PR DESCRIPTION
An entity should not change while an matter transaction is ongoing for that resource. Wrap calls and state updates in a shared mutex for the entity to avoid this.

Fixes: https://github.com/t0bst4r/home-assistant-matter-hub/issues/208