### PR TITLE
feat: add IP whitelisting to prevent unauthorized access

### DIFF
--- a/packages/backend/src/api/web-api.ts
+++ b/packages/backend/src/api/web-api.ts
@@ -53,7 +53,7 @@ export class WebApi implements Environmental.Service {
               `Client ${clientIp} was ${access ? "granted" : "denied"}`,
             );
           },
-          mode: "deny",
+          mode: "allow",
           allows: this.props.whitelist,
         }),
       );


### PR DESCRIPTION
BREAKING CHANGE: The native addon (HAOS) will use Home Assistant ingress from now on. Direct access via the port will no longer be possible.