### PR TITLE
fix(thermostat): Skip temp commands if state is unavailable

### DIFF
--- a/packages/backend/src/matter/behaviors/thermostat-server.ts
+++ b/packages/backend/src/matter/behaviors/thermostat-server.ts
@@ -106,7 +106,8 @@ export class ThermostatServerBase extends FeaturedBase {
 
   private async targetTemperatureChanged(value: number) {
     const homeAssistant = this.agent.get(HomeAssistantEntityBehavior);
-    if (homeAssistant.entity.state.state === "off") {
+    const entityState = homeAssistant.entity.state.state;
+    if (entityState == "off" || entityState == "unavailable") {
       return;
     }
     const currentAttributes = homeAssistant.entity.state


### PR DESCRIPTION
When a thermostat goes unavailable, its state loses the temperature fields which applyPatchState interprets as "no update" rather than clearing them. This in turn means that the temperature changed logic thinks that the current matter state (old temperature) differs from HA state (no temperature), requiring a service call.

We already skip temperature updates if the state is off, so let's just extend this to unavailable.

Fixes: #216 (finally)