### PR TITLE
feat(fan-control): Implement fan control cluster

### DIFF
--- a/apps/home-assistant-matter-hub/package.json
+++ b/apps/home-assistant-matter-hub/package.json
@@ -50,8 +50,8 @@
     "pack": "mkdir -p pack && npm pack --pack-destination pack --json | jq -r .[0].filename > pack/package-name.txt"
   },
   "dependencies": {
-    "@matter/main": "0.11.8",
-    "@matter/nodejs": "0.11.8",
+    "@matter/main": "0.11.9-alpha.0-20241208-09ad57f78",
+    "@matter/nodejs": "0.11.9-alpha.0-20241208-09ad57f78",
     "ajv": "8.17.1",
     "async-lock": "1.4.1",
     "chalk": "5.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,8 +50,8 @@
       "version": "3.0.0-alpha.52",
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/main": "0.11.8",
-        "@matter/nodejs": "0.11.8",
+        "@matter/main": "0.11.9-alpha.0-20241208-09ad57f78",
+        "@matter/nodejs": "0.11.9-alpha.0-20241208-09ad57f78",
         "ajv": "8.17.1",
         "async-lock": "1.4.1",
         "chalk": "5.3.0",
@@ -3240,64 +3240,64 @@
       }
     },
     "node_modules/@matter/general": {
-      "version": "0.11.8",
-      "resolved": "https://registry.npmjs.org/@matter/general/-/general-0.11.8.tgz",
-      "integrity": "sha512-DBfa8A//DNVIpPWJzxQuE81svMTwxwKKNlODEhbJSXohXG8FaYwal2tcUQJCJwVb8eyWybOgKA30oX8qhpbHZw==",
+      "version": "0.11.9-alpha.0-20241208-09ad57f78",
+      "resolved": "https://registry.npmjs.org/@matter/general/-/general-0.11.9-alpha.0-20241208-09ad57f78.tgz",
+      "integrity": "sha512-vhdfFu6Qd5f/MWg3xJy3JpGYaiYQU1arTgT6YyOxYClCKL3QOLr7ESTO7yI0K1xhGpI3vEe8rphDisACoCG/Hw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/curves": "^1.7.0"
       }
     },
     "node_modules/@matter/main": {
-      "version": "0.11.8",
-      "resolved": "https://registry.npmjs.org/@matter/main/-/main-0.11.8.tgz",
-      "integrity": "sha512-6se6hK21KzpltK0BgV3wtsKVeGaT0H9VEkQZQ51InVx7O0EQjib0PoqNorFgdubGTISJnkcR/s/0vYw4PdiDxg==",
+      "version": "0.11.9-alpha.0-20241208-09ad57f78",
+      "resolved": "https://registry.npmjs.org/@matter/main/-/main-0.11.9-alpha.0-20241208-09ad57f78.tgz",
+      "integrity": "sha512-FSPUCUj4rNQaTO9c5PfsIFeyJ2Riwz1xjQsCD3Vv2bxvLTOkMp490ZKrpJmLr5KUbkWtCHTTpz0Z0sxeY+47rA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/general": "0.11.8",
-        "@matter/model": "0.11.8",
-        "@matter/node": "0.11.8",
-        "@matter/protocol": "0.11.8",
-        "@matter/types": "0.11.8",
+        "@matter/general": "0.11.9-alpha.0-20241208-09ad57f78",
+        "@matter/model": "0.11.9-alpha.0-20241208-09ad57f78",
+        "@matter/node": "0.11.9-alpha.0-20241208-09ad57f78",
+        "@matter/protocol": "0.11.9-alpha.0-20241208-09ad57f78",
+        "@matter/types": "0.11.9-alpha.0-20241208-09ad57f78",
         "@noble/curves": "^1.7.0"
       },
       "optionalDependencies": {
-        "@matter/nodejs": "0.11.8"
+        "@matter/nodejs": "0.11.9-alpha.0-20241208-09ad57f78"
       }
     },
     "node_modules/@matter/model": {
-      "version": "0.11.8",
-      "resolved": "https://registry.npmjs.org/@matter/model/-/model-0.11.8.tgz",
-      "integrity": "sha512-EPZ8DEiVXYN4VJ3ylHj1hJVwlBJQk2QuePOfXxA2KaM1GSXUKiHW4TeyI+Jez7BzCfuWdyymCufA5grQn6pmEA==",
+      "version": "0.11.9-alpha.0-20241208-09ad57f78",
+      "resolved": "https://registry.npmjs.org/@matter/model/-/model-0.11.9-alpha.0-20241208-09ad57f78.tgz",
+      "integrity": "sha512-TgEy6JHgDTE1FhKL8kaUJgjPtiGZ4TU07I1RxFNKKiInk5sv2i+zogR9N1lTD/WJka3ALfkKMkDYkRPQXfiuhw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/general": "0.11.8",
+        "@matter/general": "0.11.9-alpha.0-20241208-09ad57f78",
         "@noble/curves": "^1.7.0"
       }
     },
     "node_modules/@matter/node": {
-      "version": "0.11.8",
-      "resolved": "https://registry.npmjs.org/@matter/node/-/node-0.11.8.tgz",
-      "integrity": "sha512-TqcsQGlclFcXw5MpnhF4xFSp6B90IDpDDafYRlO+/Zoe4HojdLnRWHyA3OJfoQy7+HXSDVy2aqVi591KotZHng==",
+      "version": "0.11.9-alpha.0-20241208-09ad57f78",
+      "resolved": "https://registry.npmjs.org/@matter/node/-/node-0.11.9-alpha.0-20241208-09ad57f78.tgz",
+      "integrity": "sha512-FIxvAyc+mu2WPl4VxdRhn9LZjNLZwcTwzWG8J5axga3ZQML/RSltKWfOJFnqnB3uW9p3JWJPZ5p+R4eZ3NqxYg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/general": "0.11.8",
-        "@matter/model": "0.11.8",
-        "@matter/protocol": "0.11.8",
-        "@matter/types": "0.11.8",
+        "@matter/general": "0.11.9-alpha.0-20241208-09ad57f78",
+        "@matter/model": "0.11.9-alpha.0-20241208-09ad57f78",
+        "@matter/protocol": "0.11.9-alpha.0-20241208-09ad57f78",
+        "@matter/types": "0.11.9-alpha.0-20241208-09ad57f78",
         "@noble/curves": "^1.7.0"
       }
     },
     "node_modules/@matter/nodejs": {
-      "version": "0.11.8",
-      "resolved": "https://registry.npmjs.org/@matter/nodejs/-/nodejs-0.11.8.tgz",
-      "integrity": "sha512-4DuO+qnnGCrh0ppt+FkY4HN351ehuFmnrWcD7GNVvog+aNJozjbZm2KrugJczUnd8VEISDFJtUmbQWmx5vVXeA==",
+      "version": "0.11.9-alpha.0-20241208-09ad57f78",
+      "resolved": "https://registry.npmjs.org/@matter/nodejs/-/nodejs-0.11.9-alpha.0-20241208-09ad57f78.tgz",
+      "integrity": "sha512-vJTagYWrCcP8T4iewtc5dnwlWaBBYWMV3Z09GQj05PZLsK3c37daLLrjzkBMqufZlybdv4yxf9jJwhC3ZBVqGA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/general": "0.11.8",
-        "@matter/node": "0.11.8",
-        "@matter/protocol": "0.11.8",
-        "@matter/types": "0.11.8",
+        "@matter/general": "0.11.9-alpha.0-20241208-09ad57f78",
+        "@matter/node": "0.11.9-alpha.0-20241208-09ad57f78",
+        "@matter/protocol": "0.11.9-alpha.0-20241208-09ad57f78",
+        "@matter/types": "0.11.9-alpha.0-20241208-09ad57f78",
         "node-localstorage": "^3.0.5"
       },
       "engines": {
@@ -3305,25 +3305,25 @@
       }
     },
     "node_modules/@matter/protocol": {
-      "version": "0.11.8",
-      "resolved": "https://registry.npmjs.org/@matter/protocol/-/protocol-0.11.8.tgz",
-      "integrity": "sha512-/Sc/m2X4uEvMoO4g9gX17ZedPhYG2EYEmNvsX9zRMBnL+YAfX4/MrsOl+6Xr6Qe05n02doOpxaNodcQGJE5C/g==",
+      "version": "0.11.9-alpha.0-20241208-09ad57f78",
+      "resolved": "https://registry.npmjs.org/@matter/protocol/-/protocol-0.11.9-alpha.0-20241208-09ad57f78.tgz",
+      "integrity": "sha512-nz0aXAYkicS/BKGeJagKGQbSJZJUTQ5BLzYtLKEA9VoTAgyFYHdjOgd/TvUlfelDKAViMWVQF0AFrEet5MoEeQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/general": "0.11.8",
-        "@matter/model": "0.11.8",
-        "@matter/types": "0.11.8",
+        "@matter/general": "0.11.9-alpha.0-20241208-09ad57f78",
+        "@matter/model": "0.11.9-alpha.0-20241208-09ad57f78",
+        "@matter/types": "0.11.9-alpha.0-20241208-09ad57f78",
         "@noble/curves": "^1.7.0"
       }
     },
     "node_modules/@matter/types": {
-      "version": "0.11.8",
-      "resolved": "https://registry.npmjs.org/@matter/types/-/types-0.11.8.tgz",
-      "integrity": "sha512-APva+1an3NSNIP3KyYsHxQKEzSwmPn+6nWFIOCiRX3VC5+vTRRBYSAOg/0KMPApHhTrwjbB8R9AhBmPbTIVvdw==",
+      "version": "0.11.9-alpha.0-20241208-09ad57f78",
+      "resolved": "https://registry.npmjs.org/@matter/types/-/types-0.11.9-alpha.0-20241208-09ad57f78.tgz",
+      "integrity": "sha512-C/UzqQLHUDF27TW0/gCuFoTO3JBRXIE3nlL+7B918Aiz0IcY6FzcDL3x/2KIubRj9kmRZRqZCDmYtx4JIN/hjg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/general": "0.11.8",
-        "@matter/model": "0.11.8",
+        "@matter/general": "0.11.9-alpha.0-20241208-09ad57f78",
+        "@matter/model": "0.11.9-alpha.0-20241208-09ad57f78",
         "@noble/curves": "^1.7.0"
       }
     },
@@ -4382,7 +4382,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4396,7 +4395,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4410,7 +4408,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4424,7 +4421,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4438,7 +4434,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4452,7 +4447,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4466,7 +4460,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4480,7 +4473,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4494,7 +4486,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4508,7 +4499,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4522,7 +4512,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4536,7 +4525,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4550,7 +4538,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4564,7 +4551,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4578,7 +4564,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4592,7 +4577,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4606,7 +4590,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4620,7 +4603,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5594,7 +5576,7 @@
       "version": "22.9.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.9.3.tgz",
       "integrity": "sha512-F3u1fs/fce3FFk+DAxbxc78DF8x0cY09RRL8GnXLmkJ1jvx3TtPdWoTT5/NiYfI5ASqXBmfqJi9dZ3gxMx4lzw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.8"
@@ -8936,7 +8918,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -11956,7 +11937,6 @@
       "version": "8.4.49",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
       "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -12733,7 +12713,6 @@
       "version": "4.27.4",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.27.4.tgz",
       "integrity": "sha512-RLKxqHEMjh/RGLsDxAEsaLO3mWgyoU6x9w6n1ikAzet4B3gI2/3yP6PWY2p9QzRTh6MfEIXB3MwsOY0Iv3vNrw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.6"
@@ -13103,7 +13082,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -14256,7 +14234,7 @@
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
@@ -14573,7 +14551,6 @@
       "version": "5.4.11",
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.11.tgz",
       "integrity": "sha512-c7jFQRklXua0mTzneGW9QVyxFjUgwcihC4bXEtujIo2ouWCe1Ajt/amn2PCxYnhYfd5k09JX3SB7OYWFKYqj8Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.21.3",
@@ -14674,7 +14651,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14691,7 +14667,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14708,7 +14683,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14725,7 +14699,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14742,7 +14715,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14759,7 +14731,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14776,7 +14747,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14793,7 +14763,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14810,7 +14779,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14827,7 +14795,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14844,7 +14811,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14861,7 +14827,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14878,7 +14843,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14895,7 +14859,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14912,7 +14875,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14929,7 +14891,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14946,7 +14907,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14963,7 +14923,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14980,7 +14939,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14997,7 +14955,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -15014,7 +14971,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -15031,7 +14987,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -15048,7 +15003,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -15062,7 +15016,6 @@
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
       "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -15476,8 +15429,8 @@
       "version": "3.0.0-alpha.52",
       "dependencies": {
         "@home-assistant-matter-hub/common": "*",
-        "@matter/main": "0.11.8",
-        "@matter/nodejs": "0.11.8",
+        "@matter/main": "0.11.9-alpha.0-20241208-09ad57f78",
+        "@matter/nodejs": "0.11.9-alpha.0-20241208-09ad57f78",
         "ajv": "8.17.1",
         "async-lock": "1.4.1",
         "chalk": "5.3.0",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -15,8 +15,8 @@
   },
   "dependencies": {
     "@home-assistant-matter-hub/common": "*",
-    "@matter/main": "0.11.8",
-    "@matter/nodejs": "0.11.8",
+    "@matter/main": "0.11.9-alpha.0-20241208-09ad57f78",
+    "@matter/nodejs": "0.11.9-alpha.0-20241208-09ad57f78",
     "ajv": "8.17.1",
     "async-lock": "1.4.1",
     "chalk": "5.3.0",

--- a/packages/backend/src/api/matter-api.ts
+++ b/packages/backend/src/api/matter-api.ts
@@ -97,7 +97,9 @@ export function matterApi(bridgeService: BridgeService): express.Router {
     const bridgeId = req.params.bridgeId;
     const bridge = bridgeService.bridges.find((b) => b.id === bridgeId);
     if (bridge) {
-      res.status(200).json(Array.from(bridge.parts).map(deviceToJson));
+      res
+        .status(200)
+        .json(Array.from(bridge.aggregatedParts).map(deviceToJson));
     } else {
       res.status(404).send("Not Found");
     }

--- a/packages/backend/src/matter/behaviors/color-control-server.ts
+++ b/packages/backend/src/matter/behaviors/color-control-server.ts
@@ -71,16 +71,9 @@ export class ColorControlServerBase extends FeaturedBase {
       return;
     }
 
-    await homeAssistant.callAction(
-      "light",
-      "turn_on",
-      {
-        color_temp_kelvin: targetKelvin,
-      },
-      {
-        entity_id: homeAssistant.entityId,
-      },
-    );
+    await homeAssistant.callAction("light.turn_on", {
+      color_temp_kelvin: targetKelvin,
+    });
   }
 
   override async moveToHueLogic(targetHue: number) {
@@ -109,16 +102,9 @@ export class ColorControlServerBase extends FeaturedBase {
     }
     const color = ColorConverter.fromMatterHS(targetHue, targetSaturation);
     const [hue, saturation] = ColorConverter.toHomeAssistantHS(color);
-    await homeAssistant.callAction(
-      "light",
-      "turn_on",
-      {
-        hs_color: [hue, saturation],
-      },
-      {
-        entity_id: homeAssistant.entityId,
-      },
-    );
+    await homeAssistant.callAction("light.turn_on", {
+      hs_color: [hue, saturation],
+    });
   }
 
   private getMatterColor(

--- a/packages/backend/src/matter/behaviors/fan-control-server-utils.test.ts
+++ b/packages/backend/src/matter/behaviors/fan-control-server-utils.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from "vitest";
+import { FanControl } from "@matter/main/clusters";
+import utils, { FanControlFeatures } from "./fan-control-server-utils.js";
+import { FanDeviceDirection } from "@home-assistant-matter-hub/common";
+
+import FanModeSequence = FanControl.FanModeSequence;
+import FanMode = FanControl.FanMode;
+import AirflowDirection = FanControl.AirflowDirection;
+
+describe("FanControlServerUtils", () => {
+  describe("getMatterFanModeSequence", () => {
+    it.each<[FanControlFeatures, FanModeSequence]>([
+      [{ auto: true, multiSpeed: true }, FanModeSequence.OffLowMedHighAuto],
+      [{ auto: true, multiSpeed: false }, FanModeSequence.OffHighAuto],
+      [{ auto: false, multiSpeed: true }, FanModeSequence.OffLowMedHigh],
+      [{ auto: false, multiSpeed: false }, FanModeSequence.OffHigh],
+    ])("should select the correct mode (%s)", (features, expected) => {
+      expect(utils.getMatterFanModeSequence(features)).toEqual(expected);
+    });
+  });
+
+  describe("getMatterFanMode", () => {
+    it("should return off when state is off", () => {
+      expect(
+        utils.getMatterFanMode(
+          "off",
+          81,
+          undefined,
+          FanModeSequence.OffLowMedHigh,
+        ),
+      ).toEqual(FanMode.Off);
+    });
+
+    it("should return off when state is on, but percentage is 0", () => {
+      expect(
+        utils.getMatterFanMode(
+          "on",
+          0,
+          undefined,
+          FanModeSequence.OffLowMedHigh,
+        ),
+      ).toEqual(FanMode.Off);
+    });
+
+    it("should return auto when preset_mode is Auto", () => {
+      expect(
+        utils.getMatterFanMode(
+          "on",
+          75,
+          "Auto",
+          FanModeSequence.OffLowMedHighAuto,
+        ),
+      ).toEqual(FanMode.Auto);
+    });
+
+    it.each([
+      [0, FanMode.Off],
+      [1, FanMode.Low],
+      [12, FanMode.Low],
+      [33, FanMode.Low],
+      [34, FanMode.Medium],
+      [40, FanMode.Medium],
+      [50, FanMode.Medium],
+      [66, FanMode.Medium],
+      [67, FanMode.High],
+      [75, FanMode.High],
+      [90, FanMode.High],
+      [100, FanMode.High],
+    ])(
+      "should return correct mode for sequence (%s -> %s)",
+      (percentage, expected) => {
+        expect(
+          utils.getMatterFanMode(
+            "on",
+            percentage,
+            undefined,
+            FanModeSequence.OffLowMedHighAuto,
+          ),
+        ).toEqual(expected);
+      },
+    );
+  });
+
+  describe("getMatterAirflowDirection", () => {
+    it.each([
+      [FanDeviceDirection.FORWARD, AirflowDirection.Forward],
+      [FanDeviceDirection.REVERSE, AirflowDirection.Reverse],
+      [undefined, undefined],
+    ])(
+      "should select the correct matter AirflowDirection (%s)",
+      (direction, expected) => {
+        expect(utils.getMatterAirflowDirection(direction)).toEqual(expected);
+      },
+    );
+  });
+
+  describe("getDirectionFromMatter", () => {
+    it.each([
+      [AirflowDirection.Forward, FanDeviceDirection.FORWARD],
+      [AirflowDirection.Reverse, FanDeviceDirection.REVERSE],
+    ])(
+      "should select the correct matter AirflowDirection (%s)",
+      (direction, expected) => {
+        expect(utils.getDirectionFromMatter(direction)).toEqual(expected);
+      },
+    );
+  });
+
+  describe("getSpeedPercentFromMatterFanMode", () => {
+    it.each([
+      [FanMode.Off, FanModeSequence.OffLowMedHighAuto, 0],
+      [FanMode.Low, FanModeSequence.OffLowMedHighAuto, (1 / 3) * 100],
+      [FanMode.Medium, FanModeSequence.OffLowMedHighAuto, (2 / 3) * 100],
+      [FanMode.High, FanModeSequence.OffLowMedHighAuto, 100],
+      [FanMode.Low, FanModeSequence.OffLowHigh, 50],
+      [FanMode.Medium, FanModeSequence.OffLowHigh, 50],
+      [FanMode.High, FanModeSequence.OffLowHigh, 100],
+    ])(
+      "should determine the correct speed (%s & %s)",
+      (mode, sequence, expected) => {
+        expect(
+          utils.getSpeedPercentFromMatterFanMode(
+            mode as
+              | FanControl.FanMode.Off
+              | FanControl.FanMode.Low
+              | FanControl.FanMode.Medium
+              | FanControl.FanMode.High,
+            sequence,
+          ),
+        ).toEqual(expected);
+      },
+    );
+  });
+
+  describe("getNextStepValue", () => {
+    it("should increase properly", () => {
+      expect(
+        utils.getNextStepValue(2, 4, {
+          direction: FanControl.StepDirection.Increase,
+        }),
+      ).toEqual(3);
+    });
+    it("should decrease properly", () => {
+      expect(
+        utils.getNextStepValue(2, 4, {
+          direction: FanControl.StepDirection.Decrease,
+        }),
+      ).toEqual(1);
+    });
+
+    it("should wrap properly", () => {
+      expect(
+        utils.getNextStepValue(0, 4, {
+          direction: FanControl.StepDirection.Decrease,
+          wrap: true,
+          lowestOff: true,
+        }),
+      ).toEqual(4);
+    });
+
+    it("should not wrap properly", () => {
+      expect(
+        utils.getNextStepValue(0, 4, {
+          direction: FanControl.StepDirection.Decrease,
+          lowestOff: true,
+        }),
+      ).toEqual(0);
+    });
+
+    it("should ignore lowest when increasing with wrap", () => {
+      expect(
+        utils.getNextStepValue(4, 4, {
+          direction: FanControl.StepDirection.Increase,
+          lowestOff: false,
+          wrap: true,
+        }),
+      ).toEqual(1);
+    });
+
+    it("should ignore lowest when decreasing with wrap", () => {
+      expect(
+        utils.getNextStepValue(1, 4, {
+          direction: FanControl.StepDirection.Decrease,
+          lowestOff: false,
+          wrap: true,
+        }),
+      ).toEqual(4);
+    });
+  });
+});

--- a/packages/backend/src/matter/behaviors/fan-control-server-utils.ts
+++ b/packages/backend/src/matter/behaviors/fan-control-server-utils.ts
@@ -1,0 +1,185 @@
+import {
+  FanDeviceAttributes,
+  FanDeviceDirection,
+} from "@home-assistant-matter-hub/common";
+import { FanControl } from "@matter/main/clusters/fan-control";
+
+export interface FanControlFeatures {
+  auto: boolean;
+  multiSpeed: boolean;
+}
+
+/**
+ * Select best fan mode sequence based on supported features
+ * @param features The supported features
+ */
+function getMatterFanModeSequence(
+  features: FanControlFeatures,
+): FanControl.FanModeSequence {
+  if (features.multiSpeed) {
+    return features.auto
+      ? FanControl.FanModeSequence.OffLowMedHighAuto
+      : FanControl.FanModeSequence.OffLowMedHigh;
+  } else {
+    return features.auto
+      ? FanControl.FanModeSequence.OffHighAuto
+      : FanControl.FanModeSequence.OffHigh;
+  }
+}
+
+/**
+ * Select best fan mode based on the entity data and the supported sequence
+ * @param state The actual state of the entity. Used to determine if it's off.
+ * @param percentage The actual percentage of the fan. Used to determine its mode
+ * @param presetMode The current preset_mode. Used to determine "auto"
+ * @param fanModeSequence The supported sequence / supported modes
+ */
+function getMatterFanMode(
+  state: "off" | string,
+  percentage: FanDeviceAttributes["percentage"],
+  presetMode: FanDeviceAttributes["preset_mode"],
+  fanModeSequence: FanControl.FanModeSequence,
+): FanControl.FanMode {
+  percentage = percentage ?? 0;
+  if (state == "off" || percentage === 0) {
+    return FanControl.FanMode.Off;
+  } else if (_autoSupported(fanModeSequence) && presetMode == "Auto") {
+    return FanControl.FanMode.Auto;
+  }
+  const sequence = _fanModesForSequence(fanModeSequence);
+  const modeIndex = Math.ceil((percentage / 100) * sequence.length) - 1;
+  return sequence[modeIndex];
+}
+
+/**
+ * Calculate the speed level percentage based on the selected fan mode
+ * @param mode The fan mode
+ * @param fanModeSequence The supported sequence
+ */
+function getSpeedPercentFromMatterFanMode(
+  mode:
+    | FanControl.FanMode.Off
+    | FanControl.FanMode.Low
+    | FanControl.FanMode.Medium
+    | FanControl.FanMode.High,
+  fanModeSequence: FanControl.FanModeSequence,
+): number {
+  if (mode === FanControl.FanMode.Off) {
+    return 0;
+  }
+  const sequence = _fanModesForSequence(fanModeSequence);
+  let index = sequence.indexOf(mode);
+  if (index == -1) {
+    index = 0;
+  }
+  const percent = (index + 1) / sequence.length;
+  return percent * 100;
+}
+
+/**
+ * Convert Fan Direction from Home Assistant to the matter enum
+ * @param direction The fan direction
+ */
+function getMatterAirflowDirection(
+  direction?: FanDeviceDirection,
+): FanControl.AirflowDirection | undefined {
+  if (direction == FanDeviceDirection.FORWARD) {
+    return FanControl.AirflowDirection.Forward;
+  } else if (direction == FanDeviceDirection.REVERSE) {
+    return FanControl.AirflowDirection.Reverse;
+  }
+  return undefined;
+}
+
+/**
+ * Convert Fan Direction from matter to the Home Assistant enum
+ * @param direction The fan direction
+ */
+function getDirectionFromMatter(
+  direction: FanControl.AirflowDirection,
+): FanDeviceDirection {
+  if (direction == FanControl.AirflowDirection.Forward) {
+    return FanDeviceDirection.FORWARD;
+  }
+  return FanDeviceDirection.REVERSE;
+}
+
+/**
+ * Get the next step value. Returns the current speed if next value would be invalid.
+ * @param speed The current speed
+ * @param speedMax The max speed
+ * @param request The step request
+ */
+function getNextStepValue(
+  speed: number,
+  speedMax: number,
+  request: FanControl.StepRequest,
+): number {
+  const direction =
+    request.direction === FanControl.StepDirection.Increase ? 1 : -1;
+  let next = speed + direction;
+  if (next === 0 && !request.lowestOff) {
+    next += direction;
+  }
+  if (request.wrap) {
+    if (next < 0) {
+      next = speedMax;
+    } else if (next > speedMax) {
+      next = !request.lowestOff ? 1 : 0;
+    }
+  }
+  if (next < 0 || next > speedMax) {
+    return speed;
+  }
+  return next;
+}
+
+/**
+ * Get the list of supported fan modes (without auto and off) based on the fan mode sequence
+ * @param sequence The fan mode sequence of the fan.
+ */
+function _fanModesForSequence(
+  sequence: FanControl.FanModeSequence,
+): FanControl.FanMode[] {
+  switch (sequence) {
+    case FanControl.FanModeSequence.OffLowMedHigh:
+    case FanControl.FanModeSequence.OffLowMedHighAuto:
+      return [
+        FanControl.FanMode.Low,
+        FanControl.FanMode.Medium,
+        FanControl.FanMode.High,
+      ];
+    case FanControl.FanModeSequence.OffLowHigh:
+    case FanControl.FanModeSequence.OffLowHighAuto:
+      return [FanControl.FanMode.Low, FanControl.FanMode.High];
+    case FanControl.FanModeSequence.OffHigh:
+    case FanControl.FanModeSequence.OffHighAuto:
+      return [FanControl.FanMode.High];
+  }
+}
+
+/**
+ * Check if the current fan mode sequence supports auto mode
+ * @param sequence
+ */
+function _autoSupported(sequence: FanControl.FanModeSequence): boolean {
+  switch (sequence) {
+    case FanControl.FanModeSequence.OffLowMedHighAuto:
+    case FanControl.FanModeSequence.OffLowHighAuto:
+    case FanControl.FanModeSequence.OffHighAuto:
+      return true;
+    case FanControl.FanModeSequence.OffLowMedHigh:
+    case FanControl.FanModeSequence.OffLowHigh:
+    case FanControl.FanModeSequence.OffHigh:
+      return false;
+  }
+}
+
+export default {
+  getMatterFanModeSequence,
+  getMatterFanMode,
+  getSpeedPercentFromMatterFanMode,
+  getMatterAirflowDirection,
+  getDirectionFromMatter,
+  getNextStepValue,
+};

--- a/packages/backend/src/matter/behaviors/fan-control-server.ts
+++ b/packages/backend/src/matter/behaviors/fan-control-server.ts
@@ -1,0 +1,230 @@
+import { FanControlServer as Base } from "@matter/main/behaviors";
+import { FanControl } from "@matter/main/clusters";
+import {
+  FanDeviceAttributes,
+  FanDeviceDirection,
+  FanDeviceFeature,
+  HomeAssistantEntityInformation,
+} from "@home-assistant-matter-hub/common";
+import { HomeAssistantEntityBehavior } from "../custom-behaviors/home-assistant-entity-behavior.js";
+import { applyPatchState } from "../../utils/apply-patch-state.js";
+
+const FeaturedBase = Base.with("MultiSpeed", "AirflowDirection", "Auto");
+
+export class FanControlServer extends FeaturedBase {
+  declare state: FanControlServer.State;
+
+  override async initialize() {
+    super.initialize();
+    const homeAssistant = await this.agent.load(HomeAssistantEntityBehavior);
+    console.log(homeAssistant.entity.state);
+    console.log(this.features);
+    this.update(homeAssistant.entity);
+    this.reactTo(homeAssistant.onChange, this.update);
+    this.reactTo(
+      this.events.percentSetting$Changed,
+      this.targetPercentSettingChanged,
+    );
+    this.reactTo(this.events.fanMode$Changed, this.targetFanModeChanged);
+    if (this.features.multiSpeed) {
+      this.reactTo(
+        this.events.speedSetting$Changed,
+        this.targetSpeedSettingChanged,
+      );
+    }
+    if (this.features.airflowDirection) {
+      this.reactTo(
+        this.events.airflowDirection$Changed,
+        this.targetAirflowDirectionChanged,
+      );
+    }
+  }
+
+  private update(entity: HomeAssistantEntityInformation) {
+    const attributes = entity.state.attributes as FanDeviceAttributes;
+    const fanMode = this.getMatterFanMode(entity);
+    const isAuto = fanMode == FanControl.FanMode.Auto;
+    const percent = attributes.percentage ?? 0;
+    const speedMax = this.getSpeedMax(entity);
+    const speed = Math.ceil(speedMax * (percent * 0.01));
+
+    applyPatchState(this.state, {
+      percentSetting: isAuto ? 0 : percent,
+      percentCurrent: percent,
+      fanMode: fanMode,
+      fanModeSequence: this.features.auto
+        ? FanControl.FanModeSequence.OffHighAuto
+        : FanControl.FanModeSequence.OffHigh,
+
+      ...(this.features.multiSpeed
+        ? {
+            speedMax: speedMax,
+            speedSetting: isAuto ? 0 : speed,
+            speedCurrent: speed,
+          }
+        : {}),
+
+      ...(this.features.airflowDirection
+        ? {
+            airflowDirection: this.getMatterAirflowDirection(
+              attributes.current_direction,
+            ),
+          }
+        : {}),
+    });
+  }
+
+  private getMatterAirflowDirection(
+    direction?: FanDeviceDirection,
+  ): FanControl.AirflowDirection | undefined {
+    if (direction == FanDeviceDirection.FORWARD) {
+      return FanControl.AirflowDirection.Forward;
+    } else if (direction == FanDeviceDirection.REVERSE) {
+      return FanControl.AirflowDirection.Reverse;
+    }
+    return undefined;
+  }
+
+  private getDirectionFromMatter(
+    direction: FanControl.AirflowDirection,
+  ): FanDeviceDirection {
+    if (direction == FanControl.AirflowDirection.Forward) {
+      return FanDeviceDirection.FORWARD;
+    }
+    return FanDeviceDirection.REVERSE;
+  }
+
+  private getSpeedMax(entity: HomeAssistantEntityInformation): number {
+    const attributes = entity.state.attributes as FanDeviceAttributes;
+    const supportedFeatures = attributes.supported_features ?? 0;
+
+    if ((supportedFeatures & FanDeviceFeature.SET_SPEED) == 0) {
+      // Speed is not controllable, return a single speed level
+      return 1;
+    } else if (attributes.percentage_step) {
+      // Speed resolution is advertised, use it
+      return Math.round(100 / attributes.percentage_step);
+    }
+    return 100;
+  }
+
+  private getMatterFanMode(
+    entity: HomeAssistantEntityInformation,
+  ): FanControl.FanMode {
+    const attributes = entity.state.attributes as FanDeviceAttributes;
+    if (entity.state.state == "off") {
+      return FanControl.FanMode.Off;
+    } else if (this.features.auto && attributes.preset_mode == "Auto") {
+      return FanControl.FanMode.Auto;
+    }
+    return FanControl.FanMode.High;
+  }
+
+  private async targetSpeedSettingChanged(setting: number | null) {
+    if (setting === null) {
+      return;
+    }
+
+    const homeAssistant = this.agent.get(HomeAssistantEntityBehavior);
+    if (homeAssistant.entity.state.state === "unavailable") {
+      return;
+    }
+    const percentSetting = Math.floor((setting / this.state.speedMax) * 100);
+    const currentAttributes = homeAssistant.entity.state
+      .attributes as FanDeviceAttributes;
+    if (currentAttributes.percentage == percentSetting) {
+      return;
+    }
+
+    if (setting == 0) {
+      await homeAssistant.callAction(
+        "fan",
+        "turn_off",
+        {},
+        { entity_id: homeAssistant.entityId },
+      );
+    } else if (setting > 0) {
+      await homeAssistant.callAction(
+        "fan",
+        "turn_on",
+        { percentage: percentSetting },
+        { entity_id: homeAssistant.entityId },
+      );
+    }
+  }
+
+  private async targetPercentSettingChanged(setting: number | null) {
+    if (setting === null) {
+      return;
+    }
+
+    const homeAssistant = this.agent.get(HomeAssistantEntityBehavior);
+    if (homeAssistant.entity.state.state === "unavailable") {
+      return;
+    }
+    const currentAttributes = homeAssistant.entity.state
+      .attributes as FanDeviceAttributes;
+    if (currentAttributes.percentage == setting) {
+      return;
+    }
+
+    const method = setting == 0 ? "turn_off" : "turn_on";
+    const payload = setting == 0 ? {} : { percentage: setting };
+
+    await homeAssistant.callAction("fan", method, payload, {
+      entity_id: homeAssistant.entityId,
+    });
+  }
+
+  private async targetFanModeChanged(setting: FanControl.FanMode) {
+    const homeAssistant = this.agent.get(HomeAssistantEntityBehavior);
+    if (homeAssistant.entity.state.state === "unavailable") {
+      return;
+    }
+    const fanMode = this.getMatterFanMode(homeAssistant.entity);
+    if (fanMode == setting) {
+      return;
+    }
+    const method = setting == FanControl.FanMode.Off ? "turn_off" : "turn_on";
+    const payload: { [id: string]: string } = {};
+    if (
+      setting == FanControl.FanMode.Auto ||
+      setting == FanControl.FanMode.Smart
+    ) {
+      if (this.features.auto) {
+        payload["preset_mode"] = "Auto";
+      }
+    }
+    await homeAssistant.callAction("fan", method, payload, {
+      entity_id: homeAssistant.entityId,
+    });
+  }
+
+  private async targetAirflowDirectionChanged(
+    setting: FanControl.AirflowDirection,
+  ) {
+    const homeAssistant = this.agent.get(HomeAssistantEntityBehavior);
+    if (homeAssistant.entity.state.state === "unavailable") {
+      return;
+    }
+
+    const currentAttributes = homeAssistant.entity.state
+      .attributes as FanDeviceAttributes;
+    if (
+      this.getMatterAirflowDirection(currentAttributes.current_direction) ==
+      setting
+    ) {
+      return;
+    }
+    await homeAssistant.callAction(
+      "fan",
+      "set_direction",
+      { direction: this.getDirectionFromMatter(setting) },
+      { entity_id: homeAssistant.entityId },
+    );
+  }
+}
+
+export namespace FanControlServer {
+  export class State extends FeaturedBase.State {}
+}

--- a/packages/backend/src/matter/behaviors/fan-control-server.ts
+++ b/packages/backend/src/matter/behaviors/fan-control-server.ts
@@ -8,17 +8,17 @@ import {
 } from "@home-assistant-matter-hub/common";
 import { HomeAssistantEntityBehavior } from "../custom-behaviors/home-assistant-entity-behavior.js";
 import { applyPatchState } from "../../utils/apply-patch-state.js";
+import { testBit } from "../../utils/test-bit.js";
+import { ClusterType } from "@matter/main/types";
 
 const FeaturedBase = Base.with("MultiSpeed", "AirflowDirection", "Auto");
 
-export class FanControlServer extends FeaturedBase {
-  declare state: FanControlServer.State;
+export class FanControlServerBase extends FeaturedBase {
+  declare state: FanControlServerBase.State;
 
   override async initialize() {
     super.initialize();
     const homeAssistant = await this.agent.load(HomeAssistantEntityBehavior);
-    console.log(homeAssistant.entity.state);
-    console.log(this.features);
     this.update(homeAssistant.entity);
     this.reactTo(homeAssistant.onChange, this.update);
     this.reactTo(
@@ -74,6 +74,91 @@ export class FanControlServer extends FeaturedBase {
     });
   }
 
+  private async targetSpeedSettingChanged(speed: number | null) {
+    if (speed === null) {
+      return;
+    }
+    const percentSetting = Math.floor((speed / this.state.speedMax) * 100);
+    await this.targetPercentSettingChanged(percentSetting);
+  }
+
+  private async targetPercentSettingChanged(percentage: number | null) {
+    if (percentage === null) {
+      return;
+    }
+    const homeAssistant = this.agent.get(HomeAssistantEntityBehavior);
+    if (!homeAssistant.isAvailable) {
+      return;
+    }
+    const currentAttributes = homeAssistant.entity.state
+      .attributes as FanDeviceAttributes;
+    const current = currentAttributes.percentage;
+    if (current == percentage) {
+      return;
+    }
+    const method = percentage == 0 ? "turn_off" : "turn_on";
+    const payload = percentage == 0 ? {} : { percentage: percentage };
+    await homeAssistant.callAction("fan", method, payload, {
+      entity_id: homeAssistant.entityId,
+    });
+  }
+
+  private async targetFanModeChanged(fanMode: FanControl.FanMode) {
+    const homeAssistant = this.agent.get(HomeAssistantEntityBehavior);
+    if (!homeAssistant.isAvailable) {
+      return;
+    }
+    const current = this.getMatterFanMode(homeAssistant.entity);
+    if (current == fanMode) {
+      return;
+    }
+    const method = fanMode == FanControl.FanMode.Off ? "turn_off" : "turn_on";
+    const data =
+      this.features.auto &&
+      [FanControl.FanMode.Auto, FanControl.FanMode.Smart].includes(fanMode)
+        ? { preset_mode: "Auto" }
+        : {};
+    await homeAssistant.callAction("fan", method, data, {
+      entity_id: homeAssistant.entityId,
+    });
+  }
+
+  private async targetAirflowDirectionChanged(
+    direction: FanControl.AirflowDirection,
+  ) {
+    const homeAssistant = this.agent.get(HomeAssistantEntityBehavior);
+    if (!homeAssistant.isAvailable) {
+      return;
+    }
+
+    const currentAttributes = homeAssistant.entity.state
+      .attributes as FanDeviceAttributes;
+    const current = this.getMatterAirflowDirection(
+      currentAttributes.current_direction,
+    );
+    if (current == direction) {
+      return;
+    }
+    await homeAssistant.callAction(
+      "fan",
+      "set_direction",
+      { direction: this.getDirectionFromMatter(direction) },
+      { entity_id: homeAssistant.entityId },
+    );
+  }
+
+  private getMatterFanMode(
+    entity: HomeAssistantEntityInformation,
+  ): FanControl.FanMode {
+    const attributes = entity.state.attributes as FanDeviceAttributes;
+    if (entity.state.state == "off") {
+      return FanControl.FanMode.Off;
+    } else if (this.features.auto && attributes.preset_mode == "Auto") {
+      return FanControl.FanMode.Auto;
+    }
+    return FanControl.FanMode.High;
+  }
+
   private getMatterAirflowDirection(
     direction?: FanDeviceDirection,
   ): FanControl.AirflowDirection | undefined {
@@ -98,7 +183,7 @@ export class FanControlServer extends FeaturedBase {
     const attributes = entity.state.attributes as FanDeviceAttributes;
     const supportedFeatures = attributes.supported_features ?? 0;
 
-    if ((supportedFeatures & FanDeviceFeature.SET_SPEED) == 0) {
+    if (!testBit(supportedFeatures, FanDeviceFeature.SET_SPEED)) {
       // Speed is not controllable, return a single speed level
       return 1;
     } else if (attributes.percentage_step) {
@@ -107,124 +192,12 @@ export class FanControlServer extends FeaturedBase {
     }
     return 100;
   }
-
-  private getMatterFanMode(
-    entity: HomeAssistantEntityInformation,
-  ): FanControl.FanMode {
-    const attributes = entity.state.attributes as FanDeviceAttributes;
-    if (entity.state.state == "off") {
-      return FanControl.FanMode.Off;
-    } else if (this.features.auto && attributes.preset_mode == "Auto") {
-      return FanControl.FanMode.Auto;
-    }
-    return FanControl.FanMode.High;
-  }
-
-  private async targetSpeedSettingChanged(setting: number | null) {
-    if (setting === null) {
-      return;
-    }
-
-    const homeAssistant = this.agent.get(HomeAssistantEntityBehavior);
-    if (homeAssistant.entity.state.state === "unavailable") {
-      return;
-    }
-    const percentSetting = Math.floor((setting / this.state.speedMax) * 100);
-    const currentAttributes = homeAssistant.entity.state
-      .attributes as FanDeviceAttributes;
-    if (currentAttributes.percentage == percentSetting) {
-      return;
-    }
-
-    if (setting == 0) {
-      await homeAssistant.callAction(
-        "fan",
-        "turn_off",
-        {},
-        { entity_id: homeAssistant.entityId },
-      );
-    } else if (setting > 0) {
-      await homeAssistant.callAction(
-        "fan",
-        "turn_on",
-        { percentage: percentSetting },
-        { entity_id: homeAssistant.entityId },
-      );
-    }
-  }
-
-  private async targetPercentSettingChanged(setting: number | null) {
-    if (setting === null) {
-      return;
-    }
-
-    const homeAssistant = this.agent.get(HomeAssistantEntityBehavior);
-    if (homeAssistant.entity.state.state === "unavailable") {
-      return;
-    }
-    const currentAttributes = homeAssistant.entity.state
-      .attributes as FanDeviceAttributes;
-    if (currentAttributes.percentage == setting) {
-      return;
-    }
-
-    const method = setting == 0 ? "turn_off" : "turn_on";
-    const payload = setting == 0 ? {} : { percentage: setting };
-
-    await homeAssistant.callAction("fan", method, payload, {
-      entity_id: homeAssistant.entityId,
-    });
-  }
-
-  private async targetFanModeChanged(setting: FanControl.FanMode) {
-    const homeAssistant = this.agent.get(HomeAssistantEntityBehavior);
-    if (homeAssistant.entity.state.state === "unavailable") {
-      return;
-    }
-    const fanMode = this.getMatterFanMode(homeAssistant.entity);
-    if (fanMode == setting) {
-      return;
-    }
-    const method = setting == FanControl.FanMode.Off ? "turn_off" : "turn_on";
-    const payload: { [id: string]: string } = {};
-    if (
-      setting == FanControl.FanMode.Auto ||
-      setting == FanControl.FanMode.Smart
-    ) {
-      if (this.features.auto) {
-        payload["preset_mode"] = "Auto";
-      }
-    }
-    await homeAssistant.callAction("fan", method, payload, {
-      entity_id: homeAssistant.entityId,
-    });
-  }
-
-  private async targetAirflowDirectionChanged(
-    setting: FanControl.AirflowDirection,
-  ) {
-    const homeAssistant = this.agent.get(HomeAssistantEntityBehavior);
-    if (homeAssistant.entity.state.state === "unavailable") {
-      return;
-    }
-
-    const currentAttributes = homeAssistant.entity.state
-      .attributes as FanDeviceAttributes;
-    if (
-      this.getMatterAirflowDirection(currentAttributes.current_direction) ==
-      setting
-    ) {
-      return;
-    }
-    await homeAssistant.callAction(
-      "fan",
-      "set_direction",
-      { direction: this.getDirectionFromMatter(setting) },
-      { entity_id: homeAssistant.entityId },
-    );
-  }
 }
 
-export namespace FanControlServer {
+export namespace FanControlServerBase {
   export class State extends FeaturedBase.State {}
 }
+
+export class FanControlServer extends FanControlServerBase.for(
+  ClusterType(FanControl.Base),
+) {}

--- a/packages/backend/src/matter/behaviors/level-control-server.ts
+++ b/packages/backend/src/matter/behaviors/level-control-server.ts
@@ -44,14 +44,9 @@ export class LevelControlServer extends Base {
     if (level === current) {
       return;
     }
-    const [domain, action] = this.state.config.moveToLevel.action.split(".");
     await homeAssistant.callAction(
-      domain,
-      action,
+      this.state.config.moveToLevel.action,
       this.state.config.moveToLevel.data(level),
-      {
-        entity_id: homeAssistant.entityId,
-      },
     );
   }
 

--- a/packages/backend/src/matter/behaviors/lock-server.ts
+++ b/packages/backend/src/matter/behaviors/lock-server.ts
@@ -33,16 +33,12 @@ export class LockServer extends Base {
 
   override async lockDoor() {
     const homeAssistant = this.agent.get(HomeAssistantEntityBehavior);
-    await homeAssistant.callAction("lock", "lock", undefined, {
-      entity_id: homeAssistant.entityId,
-    });
+    await homeAssistant.callAction("lock.lock");
   }
 
   override async unlockDoor() {
     const homeAssistant = this.agent.get(HomeAssistantEntityBehavior);
-    await homeAssistant.callAction("lock", "unlock", undefined, {
-      entity_id: homeAssistant.entityId,
-    });
+    await homeAssistant.callAction("lock.unlock");
   }
 
   private getMatterLockState(state: HomeAssistantEntityState) {

--- a/packages/backend/src/matter/behaviors/on-off-server.ts
+++ b/packages/backend/src/matter/behaviors/on-off-server.ts
@@ -52,12 +52,8 @@ export class OnOffServer extends Base {
     if (this.isOn(homeAssistant.entity.state)) {
       return;
     }
-    const [domain, action] = (
-      this.state.config?.turnOn?.action ?? "homeassistant.turn_on"
-    ).split(".");
-    await homeAssistant.callAction(domain, action, undefined, {
-      entity_id: homeAssistant.entityId,
-    });
+    const action = this.state.config?.turnOn?.action ?? "homeassistant.turn_on";
+    await homeAssistant.callAction(action);
   }
 
   override async off() {
@@ -65,12 +61,9 @@ export class OnOffServer extends Base {
     if (!this.isOn(homeAssistant.entity.state)) {
       return;
     }
-    const [domain, action] = (
-      this.state.config?.turnOff?.action ?? "homeassistant.turn_off"
-    ).split(".");
-    await homeAssistant.callAction(domain, action, undefined, {
-      entity_id: homeAssistant.entityId,
-    });
+    const action =
+      this.state.config?.turnOff?.action ?? "homeassistant.turn_off";
+    await homeAssistant.callAction(action);
   }
 
   private isOn(state: HomeAssistantEntityState) {

--- a/packages/backend/src/matter/behaviors/thermostat-server.ts
+++ b/packages/backend/src/matter/behaviors/thermostat-server.ts
@@ -96,12 +96,9 @@ export class ThermostatServerBase extends FeaturedBase {
     }
     const homeAssistant = this.agent.get(HomeAssistantEntityBehavior);
     const temperature = targetTemperature / 100 + request.amount / 10;
-    await homeAssistant.callAction(
-      "climate",
-      "set_temperature",
-      { temperature },
-      { entity_id: homeAssistant.entityId },
-    );
+    await homeAssistant.callAction("climate.set_temperature", {
+      temperature,
+    });
   }
 
   private async targetTemperatureChanged(value: number) {
@@ -116,12 +113,9 @@ export class ThermostatServerBase extends FeaturedBase {
     if (value === current) {
       return;
     }
-    await homeAssistant.callAction(
-      "climate",
-      "set_temperature",
-      { temperature: value / 100 },
-      { entity_id: homeAssistant.entityId },
-    );
+    await homeAssistant.callAction("climate.set_temperature", {
+      temperature: value / 100,
+    });
   }
 
   private async systemModeChanged(systemMode: Thermostat.SystemMode) {
@@ -135,12 +129,9 @@ export class ThermostatServerBase extends FeaturedBase {
     if (systemMode === current) {
       return;
     }
-    await homeAssistant.callAction(
-      "climate",
-      "set_hvac_mode",
-      { hvac_mode: this.getHvacMode(systemMode) },
-      { entity_id: homeAssistant.entityId },
-    );
+    await homeAssistant.callAction("climate.set_hvac_mode", {
+      hvac_mode: this.getHvacMode(systemMode),
+    });
   }
 
   private getSystemMode(

--- a/packages/backend/src/matter/behaviors/window-covering-server.ts
+++ b/packages/backend/src/matter/behaviors/window-covering-server.ts
@@ -92,30 +92,15 @@ export class WindowCoveringServerBase extends FeaturedBase {
   }
   override async handleStopMovement() {
     const homeAssistant = this.agent.get(HomeAssistantEntityBehavior);
-    await homeAssistant.callAction(
-      "cover",
-      "stop_cover",
-      {},
-      { entity_id: homeAssistant.entityId },
-    );
+    await homeAssistant.callAction("cover.stop_cover");
   }
   private async handleOpen() {
     const homeAssistant = this.agent.get(HomeAssistantEntityBehavior);
-    await homeAssistant.callAction(
-      "cover",
-      "open_cover",
-      {},
-      { entity_id: homeAssistant.entityId },
-    );
+    await homeAssistant.callAction("cover.open_cover");
   }
   private async handleClose() {
     const homeAssistant = this.agent.get(HomeAssistantEntityBehavior);
-    await homeAssistant.callAction(
-      "cover",
-      "close_cover",
-      {},
-      { entity_id: homeAssistant.entityId },
-    );
+    await homeAssistant.callAction("cover.close_cover");
   }
 
   private async handleGoToPosition(targetPercent100ths: number) {
@@ -127,12 +112,9 @@ export class WindowCoveringServerBase extends FeaturedBase {
     if (targetPosition == null || targetPosition === currentPosition) {
       return;
     }
-    await homeAssistant.callAction(
-      "cover",
-      "set_cover_position",
-      { position: targetPosition },
-      { entity_id: homeAssistant.entityId },
-    );
+    await homeAssistant.callAction("cover.set_cover_position", {
+      position: targetPosition,
+    });
   }
 
   private convertLiftValue(

--- a/packages/backend/src/matter/bridge/create-device.test.ts
+++ b/packages/backend/src/matter/bridge/create-device.test.ts
@@ -122,6 +122,7 @@ const testEntities: Record<
 
 const featureFlags: BridgeFeatureFlags = {
   matterSpeakers: true,
+  matterFans: true,
 };
 
 describe("createDevice", () => {

--- a/packages/backend/src/matter/custom-behaviors/home-assistant-entity-behavior.ts
+++ b/packages/backend/src/matter/custom-behaviors/home-assistant-entity-behavior.ts
@@ -29,19 +29,17 @@ export class HomeAssistantEntityBehavior extends Behavior {
     return this.entity.state.state !== "unavailable";
   }
 
-  async callAction(
-    domain: string,
-    action: string,
-    data: object | undefined,
-    target: HassServiceTarget,
-    returnResponse?: boolean,
-  ) {
+  async callAction(action: string, data?: object | undefined) {
     const lock = this.env.get(AsyncLock);
     const actions = this.env.get(HomeAssistantActions);
+    const target: HassServiceTarget = {
+      entity_id: this.entityId,
+    };
     const lockKey = this.state.lockKey;
+    const [domain, service] = action.split(".");
     setTimeout(async () => {
       await lock.acquire(lockKey, async () =>
-        actions.callAction(domain, action, data, target, returnResponse),
+        actions.callAction(domain, service, data, target, false),
       );
     }, 0);
   }

--- a/packages/backend/src/matter/custom-behaviors/home-assistant-entity-behavior.ts
+++ b/packages/backend/src/matter/custom-behaviors/home-assistant-entity-behavior.ts
@@ -25,6 +25,10 @@ export class HomeAssistantEntityBehavior extends Behavior {
     return this.events.entity$Changed;
   }
 
+  get isAvailable(): boolean {
+    return this.entity.state.state !== "unavailable";
+  }
+
   async callAction(
     domain: string,
     action: string,

--- a/packages/backend/src/matter/devices/fan-device.ts
+++ b/packages/backend/src/matter/devices/fan-device.ts
@@ -1,85 +1,49 @@
-import {
-  FanDevice as Device,
-  OnOffPlugInUnitDevice,
-} from "@matter/main/devices";
+import { FanDevice as Device } from "@matter/main/devices";
 import { OnOffConfig, OnOffServer } from "../behaviors/on-off-server.js";
 import { BasicInformationServer } from "../behaviors/basic-information-server.js";
 import { IdentifyServer } from "../behaviors/identify-server.js";
 import { FanControlServer } from "../behaviors/fan-control-server.js";
 import {
-  BridgeFeatureFlags,
   FanDeviceAttributes,
   FanDeviceFeature,
-  HomeAssistantEntityInformation,
-  HomeAssistantEntityState,
 } from "@home-assistant-matter-hub/common";
 import { HomeAssistantEntityBehavior } from "../custom-behaviors/home-assistant-entity-behavior.js";
 import { EndpointType } from "@matter/main";
-import {
-  LevelControlConfig,
-  LevelControlServer,
-} from "../behaviors/level-control-server.js";
+import { FanControl } from "@matter/main/clusters";
+import { FeatureSelection } from "../../utils/feature-selection.js";
+import { testBit } from "../../utils/test-bit.js";
 
 const fanOnOffConfig: OnOffConfig = {
   turnOn: { action: "fan.turn_on" },
   turnOff: { action: "fan.turn_off" },
 };
 
-const PlugInUnitDeviceType = () => {
-  const fanLevelConfig: LevelControlConfig = {
-    getValue: (state: HomeAssistantEntityState<FanDeviceAttributes>) => {
-      if (state.attributes.percentage != null) {
-        return (state.attributes.percentage / 100) * 254;
-      }
-      return 0;
-    },
-    getMinValue: () => 0,
-    getMaxValue: () => 254,
-    moveToLevel: {
-      action: "fan.set_percentage",
-      data: (value) => ({ percentage: (value / 254) * 100 }),
-    },
-  };
-  return OnOffPlugInUnitDevice.with(
-    IdentifyServer,
-    BasicInformationServer,
-    OnOffServer,
-    HomeAssistantEntityBehavior,
-    LevelControlServer.set({ config: fanLevelConfig }),
-  );
-};
-
-const FanDeviceType = (entity: HomeAssistantEntityInformation) => {
-  const attributes = entity.state.attributes as FanDeviceAttributes;
-  const presetModes: string[] = attributes.preset_modes ?? [];
-  const supportedFeatures = attributes.supported_features ?? 0;
-  const features: ("Auto" | "AirflowDirection" | "MultiSpeed")[] = [
-    "MultiSpeed",
-  ];
-  if (
-    supportedFeatures & FanDeviceFeature.PRESET_MODE &&
-    presetModes.indexOf("Auto") != -1
-  ) {
+const FanControlFeatures = (supportedFeatures: number) => {
+  const features: FeatureSelection<FanControl.Cluster> = [];
+  if (testBit(supportedFeatures, FanDeviceFeature.SET_SPEED)) {
+    features.push("MultiSpeed", "Step");
+  }
+  if (testBit(supportedFeatures, FanDeviceFeature.PRESET_MODE)) {
     features.push("Auto");
   }
-  if (supportedFeatures & FanDeviceFeature.DIRECTION) {
+  if (testBit(supportedFeatures, FanDeviceFeature.DIRECTION)) {
     features.push("AirflowDirection");
   }
-  return Device.with(
-    IdentifyServer,
-    BasicInformationServer,
-    OnOffServer.set({ config: fanOnOffConfig }),
-    HomeAssistantEntityBehavior,
-    FanControlServer.with(...features),
-  );
+  return features;
 };
 
 export function FanDevice(
   homeAssistantEntity: HomeAssistantEntityBehavior.State,
-  featureFlags?: BridgeFeatureFlags,
 ): EndpointType {
-  const deviceType = featureFlags?.matterFans
-    ? FanDeviceType(homeAssistantEntity.entity)
-    : PlugInUnitDeviceType();
-  return deviceType.set({ homeAssistantEntity });
+  const attributes = homeAssistantEntity.entity.state
+    .attributes as FanDeviceAttributes;
+  const supportedFeatures = attributes.supported_features ?? 0;
+  const device = Device.with(
+    IdentifyServer,
+    BasicInformationServer,
+    OnOffServer.set({ config: fanOnOffConfig }),
+    HomeAssistantEntityBehavior,
+    FanControlServer.with(...FanControlFeatures(supportedFeatures)),
+  );
+  return device.set({ homeAssistantEntity });
 }

--- a/packages/backend/src/matter/devices/fan-device.ts
+++ b/packages/backend/src/matter/devices/fan-device.ts
@@ -1,43 +1,47 @@
-import {
-  FanDeviceAttributes,
-  HomeAssistantEntityState,
-} from "@home-assistant-matter-hub/common";
-import { OnOffPlugInUnitDevice } from "@matter/main/devices";
-import { OnOffServer } from "../behaviors/on-off-server.js";
+import { FanDevice as Device } from "@matter/main/devices";
+import { OnOffConfig, OnOffServer } from "../behaviors/on-off-server.js";
 import { BasicInformationServer } from "../behaviors/basic-information-server.js";
 import { IdentifyServer } from "../behaviors/identify-server.js";
+import { FanControlServer } from "../behaviors/fan-control-server.js";
 import {
-  LevelControlConfig,
-  LevelControlServer,
-} from "../behaviors/level-control-server.js";
+  FanDeviceAttributes,
+  FanDeviceFeature,
+} from "@home-assistant-matter-hub/common";
 import { HomeAssistantEntityBehavior } from "../custom-behaviors/home-assistant-entity-behavior.js";
 import { EndpointType } from "@matter/main";
 
-const fanLevelConfig: LevelControlConfig = {
-  getValue: (state: HomeAssistantEntityState<FanDeviceAttributes>) => {
-    if (state.attributes.percentage != null) {
-      return (state.attributes.percentage / 100) * 254;
-    }
-    return 0;
-  },
-  getMinValue: () => 0,
-  getMaxValue: () => 254,
-  moveToLevel: {
-    action: "fan.set_percentage",
-    data: (value) => ({ percentage: (value / 254) * 100 }),
-  },
+const fanOnOffConfig: OnOffConfig = {
+  turnOn: { action: "fan.turn_on" },
+  turnOff: { action: "fan.turn_off" },
 };
-
-const FanDeviceType = OnOffPlugInUnitDevice.with(
-  IdentifyServer,
-  BasicInformationServer,
-  OnOffServer,
-  HomeAssistantEntityBehavior,
-  LevelControlServer.set({ config: fanLevelConfig }),
-);
 
 export function FanDevice(
   homeAssistantEntity: HomeAssistantEntityBehavior.State,
 ): EndpointType {
-  return FanDeviceType.set({ homeAssistantEntity });
+  const attributes = homeAssistantEntity.entity.state
+    .attributes as FanDeviceAttributes;
+  const presetModes: string[] = attributes.preset_modes ?? [];
+  const supportedFeatures = attributes.supported_features ?? 0;
+
+  const features: ("Auto" | "AirflowDirection" | "MultiSpeed")[] = [
+    "MultiSpeed",
+  ];
+  if (
+    supportedFeatures & FanDeviceFeature.PRESET_MODE &&
+    presetModes.indexOf("Auto") != -1
+  ) {
+    features.push("Auto");
+  }
+  if (supportedFeatures & FanDeviceFeature.DIRECTION) {
+    features.push("AirflowDirection");
+  }
+  const deviceType = Device.with(
+    IdentifyServer,
+    BasicInformationServer,
+    OnOffServer.set({ config: fanOnOffConfig }),
+    HomeAssistantEntityBehavior,
+    FanControlServer.with(...features),
+  );
+
+  return deviceType.set({ homeAssistantEntity });
 }

--- a/packages/backend/src/matter/devices/fan-device.ts
+++ b/packages/backend/src/matter/devices/fan-device.ts
@@ -1,28 +1,58 @@
-import { FanDevice as Device } from "@matter/main/devices";
+import {
+  FanDevice as Device,
+  OnOffPlugInUnitDevice,
+} from "@matter/main/devices";
 import { OnOffConfig, OnOffServer } from "../behaviors/on-off-server.js";
 import { BasicInformationServer } from "../behaviors/basic-information-server.js";
 import { IdentifyServer } from "../behaviors/identify-server.js";
 import { FanControlServer } from "../behaviors/fan-control-server.js";
 import {
+  BridgeFeatureFlags,
   FanDeviceAttributes,
   FanDeviceFeature,
+  HomeAssistantEntityInformation,
+  HomeAssistantEntityState,
 } from "@home-assistant-matter-hub/common";
 import { HomeAssistantEntityBehavior } from "../custom-behaviors/home-assistant-entity-behavior.js";
 import { EndpointType } from "@matter/main";
+import {
+  LevelControlConfig,
+  LevelControlServer,
+} from "../behaviors/level-control-server.js";
 
 const fanOnOffConfig: OnOffConfig = {
   turnOn: { action: "fan.turn_on" },
   turnOff: { action: "fan.turn_off" },
 };
 
-export function FanDevice(
-  homeAssistantEntity: HomeAssistantEntityBehavior.State,
-): EndpointType {
-  const attributes = homeAssistantEntity.entity.state
-    .attributes as FanDeviceAttributes;
+const PlugInUnitDeviceType = () => {
+  const fanLevelConfig: LevelControlConfig = {
+    getValue: (state: HomeAssistantEntityState<FanDeviceAttributes>) => {
+      if (state.attributes.percentage != null) {
+        return (state.attributes.percentage / 100) * 254;
+      }
+      return 0;
+    },
+    getMinValue: () => 0,
+    getMaxValue: () => 254,
+    moveToLevel: {
+      action: "fan.set_percentage",
+      data: (value) => ({ percentage: (value / 254) * 100 }),
+    },
+  };
+  return OnOffPlugInUnitDevice.with(
+    IdentifyServer,
+    BasicInformationServer,
+    OnOffServer,
+    HomeAssistantEntityBehavior,
+    LevelControlServer.set({ config: fanLevelConfig }),
+  );
+};
+
+const FanDeviceType = (entity: HomeAssistantEntityInformation) => {
+  const attributes = entity.state.attributes as FanDeviceAttributes;
   const presetModes: string[] = attributes.preset_modes ?? [];
   const supportedFeatures = attributes.supported_features ?? 0;
-
   const features: ("Auto" | "AirflowDirection" | "MultiSpeed")[] = [
     "MultiSpeed",
   ];
@@ -35,13 +65,21 @@ export function FanDevice(
   if (supportedFeatures & FanDeviceFeature.DIRECTION) {
     features.push("AirflowDirection");
   }
-  const deviceType = Device.with(
+  return Device.with(
     IdentifyServer,
     BasicInformationServer,
     OnOffServer.set({ config: fanOnOffConfig }),
     HomeAssistantEntityBehavior,
     FanControlServer.with(...features),
   );
+};
 
+export function FanDevice(
+  homeAssistantEntity: HomeAssistantEntityBehavior.State,
+  featureFlags?: BridgeFeatureFlags,
+): EndpointType {
+  const deviceType = featureFlags?.matterFans
+    ? FanDeviceType(homeAssistantEntity.entity)
+    : PlugInUnitDeviceType();
   return deviceType.set({ homeAssistantEntity });
 }

--- a/packages/backend/src/utils/feature-selection.ts
+++ b/packages/backend/src/utils/feature-selection.ts
@@ -1,0 +1,5 @@
+import { ClusterType } from "@matter/main/types";
+
+export type FeatureSelection<T extends ClusterType> = Capitalize<
+  string & keyof T["features"]
+>[];

--- a/packages/common/src/bridge-data.ts
+++ b/packages/common/src/bridge-data.ts
@@ -2,6 +2,7 @@ import { HomeAssistantFilter } from "./home-assistant-filter.js";
 
 interface AllBridgeFeatureFlags {
   readonly matterSpeakers: boolean;
+  readonly matterFans: boolean;
 }
 
 export type BridgeFeatureFlags = Partial<AllBridgeFeatureFlags>;

--- a/packages/common/src/clusters/fan-control.ts
+++ b/packages/common/src/clusters/fan-control.ts
@@ -1,0 +1,34 @@
+export enum FanControlFanMode {
+  Off = 0,
+  Low = 1,
+  Medium = 2,
+  High = 3,
+  On = 4,
+  Auto = 5,
+  Smart = 6,
+}
+
+export enum FanControlAirflowDirection {
+  Forward = 0,
+  Reverse = 1,
+}
+
+export enum FanControlFanModeSequence {
+  OffLowMedHigh = 0,
+  OffLowHigh = 1,
+  OffLowMedHighAuto = 2,
+  OffLowHighAuto = 3,
+  OffHighAuto = 4,
+  OffHigh = 5,
+}
+
+export interface FanControlClusterState {
+  fanMode?: FanControlFanMode;
+  fanModeSequence?: FanControlFanModeSequence;
+  percentSetting?: number;
+  percentCurrent?: number;
+  speedMax?: number;
+  speedSetting?: number;
+  speedCurrent?: number;
+  airflowDirection?: FanControlAirflowDirection;
+}

--- a/packages/common/src/clusters/index.ts
+++ b/packages/common/src/clusters/index.ts
@@ -1,6 +1,7 @@
 export * from "./boolean-state.js";
 export * from "./color-control.js";
 export * from "./door-lock.js";
+export * from "./fan-control.js";
 export * from "./level-control.js";
 export * from "./occupancy-sensing.js";
 export * from "./on-off.js";

--- a/packages/common/src/clusters/index.ts
+++ b/packages/common/src/clusters/index.ts
@@ -22,6 +22,7 @@ export enum ClusterId {
   colorControl = "colorControl",
   doorLock = "doorLock",
   levelControl = "levelControl",
+  fanControl = "fanControl",
   occupancySensing = "occupancySensing",
   onOff = "onOff",
   relativeHumidityMeasurement = "relativeHumidityMeasurement",

--- a/packages/common/src/domains/fan.ts
+++ b/packages/common/src/domains/fan.ts
@@ -1,3 +1,25 @@
+export enum FanDeviceDirection {
+  FORWARD = "forward",
+  REVERSE = "reverse",
+}
+
+export enum FanDeviceFeature {
+  SET_SPEED = 1,
+  OSCILLATE = 2,
+  DIRECTION = 4,
+  PRESET_MODE = 8,
+  TURN_OFF = 16,
+  TURN_ON = 32,
+}
+
 export interface FanDeviceAttributes {
+  current_direction?: FanDeviceDirection;
+  is_on?: boolean;
+  oscillating?: boolean;
   percentage?: number;
+  percentage_step?: number;
+  preset_mode?: string;
+  preset_modes?: string[];
+  speed_count?: number;
+  supported_features?: number;
 }

--- a/packages/common/src/domains/fan.ts
+++ b/packages/common/src/domains/fan.ts
@@ -18,7 +18,7 @@ export interface FanDeviceAttributes {
   oscillating?: boolean;
   percentage?: number;
   percentage_step?: number;
-  preset_mode?: string;
+  preset_mode?: "Auto" | string;
   preset_modes?: string[];
   speed_count?: number;
   supported_features?: number;

--- a/packages/common/src/schemas/bridge-config-schema.ts
+++ b/packages/common/src/schemas/bridge-config-schema.ts
@@ -49,6 +49,11 @@ const featureFlagSchema: JSONSchema7 = {
       type: "boolean",
       default: false,
     },
+    matterFans: {
+      title: "Expose Fans as fan devices",
+      type: "boolean",
+      default: false,
+    },
   },
   additionalProperties: false,
 };

--- a/packages/common/src/schemas/bridge-config-schema.ts
+++ b/packages/common/src/schemas/bridge-config-schema.ts
@@ -46,11 +46,15 @@ const featureFlagSchema: JSONSchema7 = {
     matterSpeakers: {
       title:
         "Expose TVs and Speakers as speaker devices (on-off and volume only)",
+      description:
+        "Some controllers like Alexa don't support speakers via Matter",
       type: "boolean",
       default: false,
     },
     matterFans: {
-      title: "Expose Fans as fan devices",
+      title: "Full matter conformance for fans",
+      description:
+        "Most controllers only support 'off' and 'high', but not 'low' or 'medium'.",
       type: "boolean",
       default: false,
     },

--- a/packages/frontend/src/components/cluster/ClusterState.tsx
+++ b/packages/frontend/src/components/cluster/ClusterState.tsx
@@ -66,6 +66,7 @@ const renderer: Record<ClusterId, FC<{ state: unknown }> | null> = {
   [ClusterId.thermostat]: ({ state }) => (
     <ThermostatState state={state as ThermostatClusterState} />
   ),
+  [ClusterId.fanControl]: null,
   [ClusterId.homeAssistantEntity]: null,
   [ClusterId.descriptor]: null,
   [ClusterId.bridgedDeviceBasicInformation]: null,

--- a/packages/frontend/src/components/cluster/ClusterState.tsx
+++ b/packages/frontend/src/components/cluster/ClusterState.tsx
@@ -13,6 +13,7 @@ import {
   ClusterId,
   ColorControlClusterState,
   DoorLockClusterState,
+  FanControlClusterState,
   LevelControlClusterState,
   OccupancySensingClusterState,
   OnOffClusterState,
@@ -25,6 +26,7 @@ import { BooleanState } from "./states/BooleanState.tsx";
 import { RelativeHumidityMeasurementState } from "./states/RelativeHumidityMeasurementState.tsx";
 import { ThermostatState } from "./states/ThermostatState.tsx";
 import clipboard from "clipboardy";
+import { FanControlState } from "./states/FanControlState.tsx";
 
 export interface ClusterStateProps {
   clusterId: ClusterId | string;
@@ -66,7 +68,9 @@ const renderer: Record<ClusterId, FC<{ state: unknown }> | null> = {
   [ClusterId.thermostat]: ({ state }) => (
     <ThermostatState state={state as ThermostatClusterState} />
   ),
-  [ClusterId.fanControl]: null,
+  [ClusterId.fanControl]: ({ state }) => (
+    <FanControlState state={state as FanControlClusterState} />
+  ),
   [ClusterId.homeAssistantEntity]: null,
   [ClusterId.descriptor]: null,
   [ClusterId.bridgedDeviceBasicInformation]: null,

--- a/packages/frontend/src/components/cluster/states/FanControlState.tsx
+++ b/packages/frontend/src/components/cluster/states/FanControlState.tsx
@@ -1,0 +1,51 @@
+import {
+  FanControlAirflowDirection,
+  FanControlClusterState,
+  FanControlFanMode,
+} from "@home-assistant-matter-hub/common";
+import { SvgIcon } from "@mui/material";
+import PowerOffIcon from "@mui/icons-material/PowerOff";
+import PowerOnIcon from "@mui/icons-material/Power";
+import AutoAwesomeIcon from "@mui/icons-material/AutoAwesome";
+
+export interface FanControlStateProps {
+  state: FanControlClusterState;
+}
+
+const Icons: Record<FanControlFanMode, typeof SvgIcon> = {
+  [FanControlFanMode.Off]: PowerOffIcon,
+  [FanControlFanMode.Low]: PowerOnIcon,
+  [FanControlFanMode.Medium]: PowerOnIcon,
+  [FanControlFanMode.High]: PowerOnIcon,
+  [FanControlFanMode.On]: PowerOnIcon,
+  [FanControlFanMode.Auto]: AutoAwesomeIcon,
+  [FanControlFanMode.Smart]: AutoAwesomeIcon,
+};
+const Labels: Record<FanControlFanMode, string> = {
+  [FanControlFanMode.Off]: "Off",
+  [FanControlFanMode.Low]: "Low",
+  [FanControlFanMode.Medium]: "Medium",
+  [FanControlFanMode.High]: "High",
+  [FanControlFanMode.On]: "On",
+  [FanControlFanMode.Auto]: "Auto",
+  [FanControlFanMode.Smart]: "Smart",
+};
+
+export const FanControlState = ({ state }: FanControlStateProps) => {
+  const mode = state.fanMode ?? FanControlFanMode.Off;
+  const Icon = Icons[mode];
+
+  return (
+    <>
+      <Icon fontSize="medium" />
+      <span>{Labels[mode]}</span>
+      {state.percentCurrent != null && <span>, {state.percentCurrent} %</span>}
+      <span>
+        ,{" "}
+        {state.airflowDirection === FanControlAirflowDirection.Forward
+          ? "Forward"
+          : "Reverse"}
+      </span>
+    </>
+  );
+};


### PR DESCRIPTION
This allows for fan speed, auto mode and direction control. The rocking and wind features are yet to be implemented.

Test notes:
- Apple HomeKit: Great, except that turning the fan on (instead of setting it to a percentage) makes it go directly to 100%. This appears to just be what the device is request, even if it is not the behavior I want. Air direction is exposed as well, while manual/auto mode is hidden in the device details. EDIT: Sometimes it turns on to the previous value, sometimes it explicitly writes `percentSetting=100` and goes straight to 100.

- Google Home: The On/Off cluster is still the dominant control (when removed, percentage becomes dominant), with fan speed present below - no other controls. However, setting a fan speed while effective gives a "Something went wrong" in the app, as Google Home is writing the deprecated `FanMode.On` before setting a percentage, and matter.js seems to not comply with the specs wording for this exact situation.

- Alexa/SmartThings/...: No idea, would be nice to know.

Comments:
- We technically should test for TURN_OFF/TURN_ON  home assistant fan features, but the OnOffServer are already using these so I didn't add it this time around.

- For the Google Home issue, see: https://github.com/project-chip/matter.js/issues/1476