### PR TITLE
Add filter for area

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ rules will be excluded.
 > - Even when renaming a label or area, the slug doesn't change. Never.
 >
 > You can retrieve the slug using the followiung templates in Home Assistant:
+>
 > - `{{ labels() }}` - returns all labels
 > - `{{ labels("light.my_entity") }}` - returns the labels of a specific entity
 > - `{{ areas() }}` - returns all areas

--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ The `type` can be one of:
 - `domain` - the domain you want to include or exclude
 - `platform` - the integration you want to include or exclude
 - `label` - the slug of a label you want to include or exclude
+- `area` - the slug of an area you want to include or exclude
 
 The `value` property is a string containing the corresponding value. You can add multiple include or exclude rules which
 are then combined.
@@ -227,12 +228,15 @@ rules will be excluded.
 
 > [!WARNING]
 >
-> - Labels in Home Assistant are technically represented by their "slugs".
+> - Labels and areas in Home Assistant are technically represented by their "slugs".
 > - Slugs are technical identifiers used in the background.
 > - Slugs are always lowercase and only allow a-z and underscores, so everything else will be replaced with an underscore.
-> - Even when renaming a label, the slug doesn't change. Never.
+> - Even when renaming a label or area, the slug doesn't change. Never.
 >
-> All available/existing labels can be checked using the `{{ labels() }}` or `{{ labels("light.my_entity") }}` template in Home Assistant.
+> You can retrieve the slug using the followiung templates in Home Assistant:
+> - `{{ labels() }}` - returns all labels
+> - `{{ labels("light.my_entity") }}` - returns the labels of a specific entity
+> - `{{ areas() }}` - returns all areas
 
 ## 4. Frequently Asked Questions & Troubleshooting
 

--- a/packages/backend/src/matter/bridge/matcher/matches-entity-filter.ts
+++ b/packages/backend/src/matter/bridge/matcher/matches-entity-filter.ts
@@ -33,6 +33,8 @@ export function testMatcher(
       return entity.registry?.platform === matcher.value;
     case "pattern":
       return patternToRegex(matcher.value).test(entity.entity_id);
+    case "area":
+      return entity.registry?.area_id === matcher.value;
   }
   return false;
 }

--- a/packages/common/src/home-assistant-filter.ts
+++ b/packages/common/src/home-assistant-filter.ts
@@ -3,6 +3,7 @@ export enum HomeAssistantMatcherType {
   Domain = "domain",
   Platform = "platform",
   Label = "label",
+  Area = "area",
 }
 
 export interface HomeAssistantMatcher {


### PR DESCRIPTION
This PR adds an area filter to the Matter bridge, allowing entities to be included or excluded based on their assigned area in Home Assistant. 

This feature improves integration with Apple Home by enabling a bridge-per-room setup, where the bridge and its entities are automatically assigned to the correct room. It ensures that new or updated entities are properly mapped without manual intervention.