### PR TITLE
Bridged device basic information

### DIFF
--- a/packages/backend/src/home-assistant/api/get-registry.ts
+++ b/packages/backend/src/home-assistant/api/get-registry.ts
@@ -1,4 +1,7 @@
-import { HomeAssistantEntityRegistry } from "@home-assistant-matter-hub/common";
+import {
+  HomeAssistantEntityRegistry,
+  HomeAssistantDeviceRegistry,
+} from "@home-assistant-matter-hub/common";
 import { Connection } from "home-assistant-js-websocket";
 
 export async function getRegistry(
@@ -6,5 +9,13 @@ export async function getRegistry(
 ): Promise<HomeAssistantEntityRegistry[]> {
   return connection.sendMessagePromise<HomeAssistantEntityRegistry[]>({
     type: "config/entity_registry/list",
+  });
+}
+
+export async function getDeviceRegistry(
+  connection: Connection,
+): Promise<HomeAssistantDeviceRegistry[]> {
+  return connection.sendMessagePromise<HomeAssistantDeviceRegistry[]>({
+    type: "config/device_registry/list",
   });
 }

--- a/packages/backend/src/matter/behaviors/basic-information-server.ts
+++ b/packages/backend/src/matter/behaviors/basic-information-server.ts
@@ -6,6 +6,16 @@ import { applyPatchState } from "../../utils/apply-patch-state.js";
 import { BridgeDataProvider } from "../bridge/bridge-data-provider.js";
 import { VendorId } from "@matter/main";
 
+const ellipsize = (
+  str: string | undefined,
+  len: number,
+): string | undefined => {
+  if (!str || str.length <= len) {
+    return str;
+  }
+  return str.slice(0, len - 3) + "...";
+};
+
 export class BasicInformationServer extends Base {
   override async initialize(): Promise<void> {
     await super.initialize();
@@ -16,18 +26,36 @@ export class BasicInformationServer extends Base {
 
   private update(entity: HomeAssistantEntityInformation) {
     const { basicInformation } = this.env.get(BridgeDataProvider);
+    const device = entity.deviceRegistry;
     applyPatchState(this.state, {
+      // The correct vendor name is in `device?.manufacturer`, but most
+      // controllers are currently unable to show this for bridged devices, and
+      // as Alexa Media Player relies on a check for a t0bst4r vendor to avoid
+      // loops, we keep it like this for now.
+      // See: https://github.com/alandtse/alexa_media_player/pull/2730
       vendorId: VendorId(basicInformation.vendorId),
       vendorName: maxLengthOrHash(basicInformation.vendorName, 32),
-      productName: maxLengthOrHash(basicInformation.productName, 32),
-      productLabel: maxLengthOrHash(basicInformation.productLabel, 64),
+      productName:
+        (device?.model_id
+          ? ellipsize(device?.model_id, 32)
+          : ellipsize(device?.model, 32)) ??
+        maxLengthOrHash(basicInformation.productName, 32),
+      productLabel:
+        ellipsize(device?.model, 64) ??
+        maxLengthOrHash(basicInformation.productLabel, 64),
       hardwareVersion: basicInformation.hardwareVersion,
       softwareVersion: basicInformation.softwareVersion,
-      nodeLabel: maxLengthOrHash(
+      hardwareVersionString: ellipsize(device?.hw_version, 64) ?? undefined,
+      softwareVersionString: ellipsize(device?.sw_version, 64) ?? undefined,
+      nodeLabel: ellipsize(
         entity.state.attributes.friendly_name ?? entity.entity_id,
         32,
       ),
       reachable: entity.state.state !== "unavailable",
+
+      // The device serial number is available in `device?.serial_number`, but
+      // we're keeping it as the entity ID for now to avoid breaking existing
+      // deployments.
       serialNumber: maxLengthOrHash(entity.entity_id, 32),
     });
   }

--- a/packages/common/src/home-assistant-device-registry.ts
+++ b/packages/common/src/home-assistant-device-registry.ts
@@ -1,0 +1,22 @@
+export interface HomeAssistantDeviceRegistry {
+  area_id?: unknown;
+  config_entries?: unknown;
+  configuration_url?: unknown;
+  connections?: unknown;
+  default_manufacturer?: string;
+  default_model?: string;
+  default_name?: string;
+  entry_type?: unknown;
+  hw_version?: string;
+  id?: string;
+  identifiers?: unknown;
+  name?: string;
+  name_by_user?: string;
+  manufacturer?: string;
+  model?: string;
+  model_id?: string;
+  serial_number?: string;
+  suggested_area?: unknown;
+  sw_version?: string;
+  via_device?: unknown;
+}

--- a/packages/common/src/home-assistant-entity-information.ts
+++ b/packages/common/src/home-assistant-entity-information.ts
@@ -1,8 +1,10 @@
 import { HomeAssistantEntityState } from "./home-assistant-entity-state.js";
 import { HomeAssistantEntityRegistry } from "./home-assistant-entity-registry.js";
+import { HomeAssistantDeviceRegistry } from "./home-assistant-device-registry.js";
 
 export interface HomeAssistantEntityInformation {
   entity_id: string;
   registry?: HomeAssistantEntityRegistry;
+  deviceRegistry?: HomeAssistantDeviceRegistry;
   state: HomeAssistantEntityState;
 }

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./bridge-data.js";
 export * from "./home-assistant-filter.js";
+export * from "./home-assistant-device-registry.js";
 export * from "./home-assistant-entity-registry.js";
 export * from "./home-assistant-entity-state.js";
 export * from "./home-assistant-entity-information.js";


### PR DESCRIPTION
Plumb through the actual bridged device details. Google Home only seems to pick up the product name, but "Technical Information" seems to always give the bridge details which is a bit borked but just seems like a Google Home bug - the matter.js shell shows the details correctly. Google Home also does not seem to reload the details after a device has been added.

~~Z2M seems to not fill out the extended details properly (model_id for example), and so tends to create rather long strings which are cut to length with "..." at the end. These should be improved on the Z2M side. EDIT: https://github.com/Koenkk/zigbee2mqtt/pull/25389~~ Merged