### PR TITLE
speaker: Source selection, mute and volume fixes

### DIFF
--- a/packages/backend/src/matter/behaviors/media-input-server.ts
+++ b/packages/backend/src/matter/behaviors/media-input-server.ts
@@ -1,0 +1,51 @@
+import {
+  HomeAssistantEntityInformation,
+  MediaPlayerDeviceAttributes,
+} from "@home-assistant-matter-hub/common";
+import { HomeAssistantEntityBehavior } from "../custom-behaviors/home-assistant-entity-behavior.js";
+import { MediaInputServer as Base } from "@matter/main/behaviors";
+import { MediaInput } from "@matter/main/clusters";
+import { applyPatchState } from "../../utils/apply-patch-state.js";
+
+export class MediaInputServer extends Base {
+  declare state: MediaInputServer.State;
+
+  override async initialize() {
+    super.initialize();
+    const homeAssistant = await this.agent.load(HomeAssistantEntityBehavior);
+    this.update(homeAssistant.entity);
+    this.reactTo(homeAssistant.onChange, this.update);
+  }
+
+  private update(entity: HomeAssistantEntityInformation) {
+    const attributes = entity.state.attributes as MediaPlayerDeviceAttributes;
+    let source_idx = 0;
+    const sources = attributes.source_list?.map((source) => ({
+      index: source_idx++,
+      inputType: MediaInput.InputType.Hdmi,
+      name: source,
+      description: source,
+    }));
+    let currentInput = attributes.source_list?.indexOf(attributes.source ?? "");
+    currentInput = currentInput == -1 ? 0 : currentInput;
+    applyPatchState(this.state, {
+      inputList: sources,
+      currentInput: currentInput,
+    });
+  }
+
+  override async selectInput(request: MediaInput.SelectInputRequest) {
+    const homeAssistant = this.agent.get(HomeAssistantEntityBehavior);
+    const target = this.state.inputList[request.index];
+    await homeAssistant.callAction("media_player.select_source", {
+      source: target.name,
+    });
+  }
+
+  override async showInputStatus() {}
+  override async hideInputStatus() {}
+}
+
+export namespace MediaInputServer {
+  export class State extends Base.State {}
+}

--- a/packages/backend/src/matter/behaviors/media-input-server.ts
+++ b/packages/backend/src/matter/behaviors/media-input-server.ts
@@ -20,17 +20,19 @@ export class MediaInputServer extends Base {
   private update(entity: HomeAssistantEntityInformation) {
     const attributes = entity.state.attributes as MediaPlayerDeviceAttributes;
     let source_idx = 0;
-    const sources = attributes.source_list?.map((source) => ({
+    const inputList = attributes.source_list?.map((source) => ({
       index: source_idx++,
-      inputType: MediaInput.InputType.Hdmi,
+      inputType: MediaInput.InputType.Other,
       name: source,
       description: source,
     }));
     let currentInput = attributes.source_list?.indexOf(attributes.source ?? "");
-    currentInput = currentInput == -1 ? 0 : currentInput;
+    if (currentInput === -1) {
+      currentInput = 0;
+    }
     applyPatchState(this.state, {
-      inputList: sources,
-      currentInput: currentInput,
+      inputList,
+      currentInput,
     });
   }
 

--- a/packages/backend/src/matter/behaviors/on-off-server.ts
+++ b/packages/backend/src/matter/behaviors/on-off-server.ts
@@ -10,9 +10,11 @@ export interface OnOffConfig {
   isOn?: (state: HomeAssistantEntityState) => boolean;
   turnOn?: {
     action: string;
+    data?: object;
   };
   turnOff?: {
     action: string;
+    data?: object;
   };
 }
 
@@ -35,14 +37,16 @@ export class OnOffServer extends Base {
   override async on() {
     const homeAssistant = this.agent.get(HomeAssistantEntityBehavior);
     const action = this.state.config?.turnOn?.action ?? "homeassistant.turn_on";
-    await homeAssistant.callAction(action);
+    const data = this.state.config?.turnOn?.data;
+    await homeAssistant.callAction(action, data);
   }
 
   override async off() {
     const homeAssistant = this.agent.get(HomeAssistantEntityBehavior);
     const action =
       this.state.config?.turnOff?.action ?? "homeassistant.turn_off";
-    await homeAssistant.callAction(action);
+    const data = this.state.config?.turnOff?.data;
+    await homeAssistant.callAction(action, data);
   }
 
   private isOn(state: HomeAssistantEntityState) {

--- a/packages/backend/src/matter/bridge/create-device.test.ts
+++ b/packages/backend/src/matter/bridge/create-device.test.ts
@@ -18,6 +18,7 @@ import {
   LightDeviceColorMode,
   SensorDeviceAttributes,
   SensorDeviceClass,
+  MediaPlayerDeviceFeature,
 } from "@home-assistant-matter-hub/common";
 import { createDevice } from "./create-device.js";
 import _ from "lodash";
@@ -112,7 +113,11 @@ const testEntities: Record<
     createEntity("input_boolean.input_boolean1", "on"),
   ],
   [HomeAssistantDomain.input_button]: [createEntity("input_button.ib1", "any")],
-  [HomeAssistantDomain.media_player]: [createEntity("media_player.m1", "on")],
+  [HomeAssistantDomain.media_player]: [
+    createEntity("media_player.m1", "on", {
+      supported_features: MediaPlayerDeviceFeature.SELECT_SOURCE,
+    }),
+  ],
   [HomeAssistantDomain.humidifier]: [
     createEntity<HumidiferDeviceAttributes>("humidifier.h1", "on", {
       min_humidity: 15,

--- a/packages/backend/src/matter/devices/media-player-device.ts
+++ b/packages/backend/src/matter/devices/media-player-device.ts
@@ -6,13 +6,27 @@ import {
 import { SpeakerDevice } from "@matter/main/devices";
 import { BasicInformationServer } from "../behaviors/basic-information-server.js";
 import { IdentifyServer } from "../behaviors/identify-server.js";
-import { OnOffServer } from "../behaviors/on-off-server.js";
+import { OnOffServer, OnOffConfig } from "../behaviors/on-off-server.js";
 import {
   LevelControlConfig,
   LevelControlServer,
 } from "../behaviors/level-control-server.js";
 import { HomeAssistantEntityBehavior } from "../custom-behaviors/home-assistant-entity-behavior.js";
 import { OnOffPlugInUnitDevice } from "@matter/main/devices";
+
+const muteOnOffConfig: OnOffConfig = {
+  turnOn: {
+    action: "media_player.volume_mute",
+    data: { is_volume_muted: false },
+  },
+  turnOff: {
+    action: "media_player.volume_mute",
+    data: { is_volume_muted: true },
+  },
+  isOn: (state: HomeAssistantEntityState<MediaPlayerDeviceAttributes>) => {
+    return !state.attributes.is_volume_muted;
+  },
+};
 
 const FallbackEndpointType = OnOffPlugInUnitDevice.with(
   BasicInformationServer,
@@ -40,7 +54,7 @@ const MediaPlayerEndpointType = SpeakerDevice.with(
   BasicInformationServer,
   IdentifyServer,
   HomeAssistantEntityBehavior,
-  OnOffServer,
+  OnOffServer.set({ config: muteOnOffConfig }),
   LevelControlServer.set({ config: volumeLevelConfig }),
 );
 

--- a/packages/backend/src/matter/devices/media-player-device.ts
+++ b/packages/backend/src/matter/devices/media-player-device.ts
@@ -38,14 +38,16 @@ const FallbackEndpointType = OnOffPlugInUnitDevice.with(
 const volumeLevelConfig: LevelControlConfig = {
   getValue: (state: HomeAssistantEntityState<MediaPlayerDeviceAttributes>) => {
     if (state.attributes.volume_level != null) {
-      return state.attributes.volume_level * 254;
+      return state.attributes.volume_level * 100;
     }
     return 0;
   },
+  getMinValue: (_: HomeAssistantEntityState) => 0,
+  getMaxValue: (_: HomeAssistantEntityState) => 100,
   moveToLevel: {
     action: "media_player.volume_set",
     data: (value) => {
-      return { volume_level: value / 254 };
+      return { volume_level: value / 100 };
     },
   },
 };

--- a/packages/common/src/clusters/index.ts
+++ b/packages/common/src/clusters/index.ts
@@ -9,6 +9,7 @@ export * from "./relative-humidity-measurement.js";
 export * from "./temperature-measurement.js";
 export * from "./thermostat.js";
 export * from "./window-covering.js";
+export * from "./media-input.js";
 
 export enum ClusterId {
   homeAssistantEntity = "homeAssistantEntity",
@@ -30,4 +31,5 @@ export enum ClusterId {
   temperatureMeasurement = "temperatureMeasurement",
   thermostat = "thermostat",
   windowCovering = "windowCovering",
+  mediaInput = "mediaInput",
 }

--- a/packages/common/src/clusters/media-input.ts
+++ b/packages/common/src/clusters/media-input.ts
@@ -1,0 +1,11 @@
+export interface MediaInputInputInfo {
+  index: number;
+  inputType: number;
+  name: string;
+  description: string;
+}
+
+export interface MediaInputClusterState {
+  currentInput?: number;
+  inputList?: MediaInputInputInfo[];
+}

--- a/packages/common/src/domains/media-player.ts
+++ b/packages/common/src/domains/media-player.ts
@@ -8,4 +8,5 @@ export enum MediaPlayerDeviceClass {
 export interface MediaPlayerDeviceAttributes {
   device_class?: MediaPlayerDeviceClass;
   volume_level?: number;
+  is_volume_muted?: boolean;
 }

--- a/packages/common/src/domains/media-player.ts
+++ b/packages/common/src/domains/media-player.ts
@@ -5,8 +5,35 @@ export enum MediaPlayerDeviceClass {
   Receiver = "receiver",
 }
 
+export enum MediaPlayerDeviceFeature {
+  PAUSE = 1,
+  SEEK = 2,
+  VOLUME_SET = 4,
+  VOLUME_MUTE = 8,
+  PREVIOUS_TRACK = 16,
+  NEXT_TRACK = 32,
+  TURN_ON = 128,
+  TURN_OFF = 256,
+  PLAY_MEDIA = 512,
+  VOLUME_STEP = 1024,
+  SELECT_SOURCE = 2048,
+  STOP = 4096,
+  CLEAR_PLAYLIST = 8192,
+  PLAY = 16384,
+  SHUFFLE_SET = 32768,
+  SELECT_SOUND_MODE = 65536,
+  BROWSE_MEDIA = 131072,
+  REPEAT_SET = 262144,
+  GROUPING = 524288,
+  MEDIA_ANNOUNCE = 1048576,
+  MEDIA_ENQUEUE = 2097152,
+}
+
 export interface MediaPlayerDeviceAttributes {
   device_class?: MediaPlayerDeviceClass;
   volume_level?: number;
   is_volume_muted?: boolean;
+  source?: string;
+  source_list?: string[];
+  supported_features?: number;
 }

--- a/packages/frontend/src/components/cluster/ClusterState.tsx
+++ b/packages/frontend/src/components/cluster/ClusterState.tsx
@@ -8,6 +8,7 @@ import { DoorLockState } from "./states/DoorLockState.tsx";
 import { WindowCoveringState } from "./states/WindowCoveringState.tsx";
 import { TemperatureMeasurementState } from "./states/TemperatureMeasurementState.tsx";
 import { OccupancySensingState } from "./states/OccupancySensingState.tsx";
+import { MediaInputState } from "./states/MediaInputState.tsx";
 import {
   BooleanStateClusterState,
   ClusterId,
@@ -21,6 +22,7 @@ import {
   TemperatureMeasurementClusterState,
   ThermostatClusterState,
   WindowCoveringClusterState,
+  MediaInputClusterState,
 } from "@home-assistant-matter-hub/common";
 import { BooleanState } from "./states/BooleanState.tsx";
 import { RelativeHumidityMeasurementState } from "./states/RelativeHumidityMeasurementState.tsx";
@@ -70,6 +72,9 @@ const renderer: Record<ClusterId, FC<{ state: unknown }> | null> = {
   ),
   [ClusterId.fanControl]: ({ state }) => (
     <FanControlState state={state as FanControlClusterState} />
+  ),
+  [ClusterId.mediaInput]: ({ state }) => (
+    <MediaInputState state={state as MediaInputClusterState} />
   ),
   [ClusterId.homeAssistantEntity]: null,
   [ClusterId.descriptor]: null,

--- a/packages/frontend/src/components/cluster/states/MediaInputState.tsx
+++ b/packages/frontend/src/components/cluster/states/MediaInputState.tsx
@@ -1,0 +1,20 @@
+import { MediaInputClusterState } from "@home-assistant-matter-hub/common";
+import InputIcon from "@mui/icons-material/Input";
+
+export interface MediaInputStateProps {
+  state: MediaInputClusterState;
+}
+
+export const MediaInputState = ({ state }: MediaInputStateProps) => {
+  const input = state.inputList?.find(
+    (input) => input.index === state.currentInput,
+  );
+  const inputText = input ? input.name : "Unknown";
+  console.log(input, inputText, state);
+  return (
+    <>
+      <InputIcon fontSize="medium" />
+      <span>{inputText}</span>
+    </>
+  );
+};

--- a/packages/frontend/src/components/cluster/states/MediaInputState.tsx
+++ b/packages/frontend/src/components/cluster/states/MediaInputState.tsx
@@ -1,20 +1,20 @@
 import { MediaInputClusterState } from "@home-assistant-matter-hub/common";
 import InputIcon from "@mui/icons-material/Input";
+import { useMemo } from "react";
 
 export interface MediaInputStateProps {
   state: MediaInputClusterState;
 }
 
 export const MediaInputState = ({ state }: MediaInputStateProps) => {
-  const input = state.inputList?.find(
-    (input) => input.index === state.currentInput,
+  const input = useMemo(
+    () => state.inputList?.find((input) => input.index === state.currentInput),
+    [state],
   );
-  const inputText = input ? input.name : "Unknown";
-  console.log(input, inputText, state);
   return (
     <>
       <InputIcon fontSize="medium" />
-      <span>{inputText}</span>
+      <span>{input?.name ?? "Unknown"}</span>
     </>
   );
 };


### PR DESCRIPTION
This PR has the following improvements for Speaker devices:

1. Mute was broken and instead controlled power. It has been changed to control mute. Controlling power for a Speaker device requires a second endpoint for the device, which is not implemented.

2. Volume from Google Home was both set and displayed wrong, which is a Google Home bug that also happens with Google's own Matter Virtual Device test app. Explicitly setting a 0-100 range makes volume set work, while the readout afterwards still glitches.

3. Source selection has been implemented, and works to show the source in Google Home. Setting the source fails, but that is also the case with the Google Matter Virtual Device test app and thus probably a Google Home bug. It works from the matter.js shell.

4. Mute and Volume was exposed unconditionally, despite being behind Home Assistant feature flags.

Neither mute nor volume worked as intended in Google Home. Now only volume readout is broken. Source selection added when supported.