### PR TITLE
feat: allow filtering by entity_category

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ The `type` can be one of:
 - `pattern` - a pattern matching your entity ids
 - `domain` - the domain you want to include or exclude
 - `platform` - the integration you want to include or exclude
+- `entity_category` - the [entity category](https://developers.home-assistant.io/docs/core/entity/#registry-properties) (`configuration` / `diagnostic`) you want to include or exclude
 - `label` - the slug of a label you want to include or exclude
 - `area` - the slug of an area you want to include or exclude
 
@@ -229,6 +230,10 @@ rules will be excluded.
       {
         "type": "domain",
         "value": "fan"
+      },
+      {
+        "type": "entity_category",
+        "value": "diagnostic"
       }
     ]
   }

--- a/packages/backend/src/matter/bridge/matcher/matches-entity-filter.test.ts
+++ b/packages/backend/src/matter/bridge/matcher/matches-entity-filter.test.ts
@@ -14,6 +14,7 @@ const registry: HomeAssistantEntityRegistry = {
   has_entity_name: true,
   original_name: "any",
   unique_id: "unique_id",
+  entity_category: "diagnostic",
   platform: "hue",
   labels: ["test_label"],
 };
@@ -81,6 +82,23 @@ describe("matchEntityFilter.testMatcher", () => {
       testMatcher(entity, {
         type: HomeAssistantMatcherType.Platform,
         value: "not_hue",
+      }),
+    ).toBeFalsy();
+  });
+
+  it("should match the entity category", () => {
+    expect(
+      testMatcher(entity, {
+        type: HomeAssistantMatcherType.EntityCategory,
+        value: "diagnostic",
+      }),
+    ).toBeTruthy();
+  });
+  it("should not match the entity category", () => {
+    expect(
+      testMatcher(entity, {
+        type: HomeAssistantMatcherType.EntityCategory,
+        value: "configuration",
       }),
     ).toBeFalsy();
   });

--- a/packages/backend/src/matter/bridge/matcher/matches-entity-filter.ts
+++ b/packages/backend/src/matter/bridge/matcher/matches-entity-filter.ts
@@ -29,6 +29,8 @@ export function testMatcher(
         !!entity.registry?.labels &&
         entity.registry.labels.includes(matcher.value)
       );
+    case "entity_category":
+      return entity.registry?.entity_category === matcher.value;
     case "platform":
       return entity.registry?.platform === matcher.value;
     case "pattern":

--- a/packages/common/src/home-assistant-filter.ts
+++ b/packages/common/src/home-assistant-filter.ts
@@ -4,6 +4,7 @@ export enum HomeAssistantMatcherType {
   Platform = "platform",
   Label = "label",
   Area = "area",
+  EntityCategory = "entity_category",
 }
 
 export interface HomeAssistantMatcher {


### PR DESCRIPTION
This adds another filter to allow including / excluding entities by their entity_categories.
With this, a bridge can exclude entities like some_ contact sensors for connected ESPHome devices and some internal temperature sensors that indicate that my living room no longer supports human life :)

![Screenshot 2025-01-05 at 11 15 03](https://github.com/user-attachments/assets/a16c580e-7e1c-4958-938f-47f174832a38)
