### PR TITLE
Use device area if available for entities that have no area directly set

### DIFF
--- a/packages/backend/src/matter/bridge/matcher/matches-entity-filter.test.ts
+++ b/packages/backend/src/matter/bridge/matcher/matches-entity-filter.test.ts
@@ -5,6 +5,7 @@ import {
   HomeAssistantEntityRegistry,
   HomeAssistantEntityState,
   HomeAssistantMatcherType,
+  HomeAssistantDeviceRegistry,
 } from "@home-assistant-matter-hub/common";
 
 const registry: HomeAssistantEntityRegistry = {
@@ -19,6 +20,8 @@ const registry: HomeAssistantEntityRegistry = {
   labels: ["test_label"],
 };
 
+const registryWithArea = { ...registry, area_id: "area_id" };
+
 const state: HomeAssistantEntityState = {
   entity_id: "light.my_entity",
   state: "on",
@@ -28,11 +31,19 @@ const state: HomeAssistantEntityState = {
   attributes: {},
 };
 
+const deviceRegistry: HomeAssistantDeviceRegistry = {
+  area_id: "area_id",
+};
+
 const entity: HomeAssistantEntityInformation = {
   entity_id: "light.my_entity",
   registry,
   state,
 };
+
+const entityWithArea = { ...entity, registry: registryWithArea };
+
+const entityWithDevice = { ...entity, deviceRegistry };
 
 describe("matchEntityFilter.testMatcher", () => {
   it("should match the domain", () => {
@@ -86,6 +97,54 @@ describe("matchEntityFilter.testMatcher", () => {
     ).toBeFalsy();
   });
 
+  it("should match the area", () => {
+    expect(
+      testMatcher(entityWithArea, {
+        type: HomeAssistantMatcherType.Area,
+        value: "area_id",
+      }),
+    ).toBeTruthy();
+  });
+  it("should not match the area", () => {
+    expect(
+      testMatcher(entityWithArea, {
+        type: HomeAssistantMatcherType.Area,
+        value: "another_area_id",
+      }),
+    ).toBeFalsy();
+  });
+  it("should match the device area when entity has no area", () => {
+    expect(
+      testMatcher(entityWithDevice, {
+        type: HomeAssistantMatcherType.Area,
+        value: "area_id",
+      }),
+    ).toBeTruthy();
+  });
+  it("should not match the device area when entity has no area", () => {
+    expect(
+      testMatcher(entityWithDevice, {
+        type: HomeAssistantMatcherType.Area,
+        value: "another_area_id",
+      }),
+    ).toBeFalsy();
+  });
+  it("should match when entity and device are in different areas", () => {
+    expect(
+      testMatcher(entityWithArea, {
+        type: HomeAssistantMatcherType.Area,
+        value: "area_id",
+      }),
+    ).toBeTruthy();
+  });
+  it("should not match when entity and device are in different areas", () => {
+    expect(
+      testMatcher(entityWithArea, {
+        type: HomeAssistantMatcherType.Area,
+        value: "another_area_id",
+      }),
+    ).toBeFalsy();
+  });
   it("should match the entity category", () => {
     expect(
       testMatcher(entity, {

--- a/packages/backend/src/matter/bridge/matcher/matches-entity-filter.ts
+++ b/packages/backend/src/matter/bridge/matcher/matches-entity-filter.ts
@@ -36,7 +36,10 @@ export function testMatcher(
     case "pattern":
       return patternToRegex(matcher.value).test(entity.entity_id);
     case "area":
-      return entity.registry?.area_id === matcher.value;
+      return (
+        (entity.registry?.area_id ?? entity.deviceRegistry?.area_id) ===
+        matcher.value
+      );
   }
   return false;
 }


### PR DESCRIPTION
I loved the motivation in #314 to use one bridge per area but most entities in home assistant inherit their areas from the device they belong to, resulting a `null` area_id in the entity registry, making the filter only return entities that have their area manually set or entities that nave no devices like automations.

This PR uses the device area when the entity has a null area_id.