### PR TITLE
Fix_light_level_math

### DIFF
--- a/packages/backend/src/matter/devices/light/light-level-control-server.ts
+++ b/packages/backend/src/matter/devices/light/light-level-control-server.ts
@@ -11,13 +11,15 @@ const levelControlConfig: LevelControlConfig = {
   getValue: (state: HomeAssistantEntityState<LightDeviceAttributes>) => {
     const brightness = state.attributes.brightness;
     if (brightness != null) {
-      return (brightness / 255) * 254;
+      return Math.round((brightness / 255) * 254);
     }
     return null;
   },
   moveToLevel: {
     action: "light.turn_on",
-    data: (brightness) => ({ brightness: (brightness / 254) * 255 }),
+    data: (brightness) => ({
+      brightness: Math.round((brightness / 254) * 255),
+    }),
   },
   expandMinMaxForValue: true,
 };

--- a/packages/common/src/utils/color-converter.ts
+++ b/packages/common/src/utils/color-converter.ts
@@ -2,9 +2,9 @@ import Color from "color";
 
 /*
  * Matter:
- *    Brightness: 0-255
- *    Hue: 0-255
- *    Saturation: 0-255
+ *    Brightness: 0-254
+ *    Hue: 0-254
+ *    Saturation: 0-254
  *    colorTemperatureMireds: Samples 147 - 454
  *
  * Home Assistant:
@@ -37,7 +37,11 @@ export abstract class ColorConverter {
    * @return Color
    */
   public static fromMatterHS(hue: number, saturation: number): Color {
-    return Color.hsv((hue / 254) * 360, (saturation / 254) * 100, 100);
+    return Color.hsv(
+      Math.round((hue / 254) * 360),
+      Math.round((saturation / 254) * 100),
+      100,
+    );
   }
 
   /**
@@ -128,7 +132,7 @@ export abstract class ColorConverter {
    */
   public static toMatterHS(color: Color): [hue: number, saturation: number] {
     const [h, s] = color.hsv().array();
-    return [(h / 360) * 254, (s / 100) * 254];
+    return [Math.round((h / 360) * 254), Math.round((s / 100) * 254)];
   }
 
   /**


### PR DESCRIPTION
Since the brightness in home assistant entity is stored as an integer and matter passes the value as an integer, but with slightly different max, we must round it to the closest value when converting.

This causes incorrect values in consumer solutions such as the below.
1. 10% = Matter 25 = converted 25.098425196850396 = homeassistant 25 = converted back 24.901960784313725 = Matter 24 = 9%
2. 90% = Matter 229 = converted 229.9015748031496 = homeassistant 229 = converted back 228.101960784313725 = Matter 228 = 89%