### PR TITLE
fix(basic-information-server): Use device vendor

### DIFF
--- a/packages/backend/src/matter/behaviors/basic-information-server.ts
+++ b/packages/backend/src/matter/behaviors/basic-information-server.ts
@@ -18,13 +18,10 @@ export class BasicInformationServer extends Base {
     const { basicInformation } = this.env.get(BridgeDataProvider);
     const device = entity.deviceRegistry;
     applyPatchState(this.state, {
-      // The correct vendor name is in `device?.manufacturer`, but most
-      // controllers are currently unable to show this for bridged devices, and
-      // as Alexa Media Player relies on a check for a t0bst4r vendor to avoid
-      // loops, we keep it like this for now.
-      // See: https://github.com/alandtse/alexa_media_player/pull/2730
       vendorId: VendorId(basicInformation.vendorId),
-      vendorName: hash(32, basicInformation.vendorName),
+      vendorName:
+        ellipse(32, device?.manufacturer) ??
+        hash(32, basicInformation.vendorName),
       productName:
         ellipse(32, device?.model_id) ??
         ellipse(32, device?.model) ??


### PR DESCRIPTION
We previously kept the t0bst4r vendor on all bridged devices to support a workaround present in Alexa Media Player that relied on the vendor to detect if a device was bridged from home assistant to avoid loops.

As of version 5.4.0, Alexa Media Player understands the relationship between our bridge and our bridged devices, and only needs to recognize the vendor of the bridge itself.

Report the correct vendor for bridged devices as the workaround is no longer relevant.

References: github.com/alandtse/alexa_media_player/pull/2792