### PR TITLE
Support On/Off server for climate device (room air conditioner), to control on/off it via Alexa

### DIFF
--- a/packages/backend/src/matter/devices/climate-device.ts
+++ b/packages/backend/src/matter/devices/climate-device.ts
@@ -19,8 +19,8 @@ import { Thermostat } from "@matter/main/clusters";
 import { ClusterType } from "@matter/main/types";
 
 const climateOnOffConfig: OnOffConfig = {
-   turnOn: { action: "climate.turn_on" },
-   turnOff: { action: "climate.turn_off" },
+  turnOn: { action: "climate.turn_on" },
+  turnOff: { action: "climate.turn_off" },
 };
 const humidityConfig: HumidityMeasurementConfig = {
   getValue(entity: HomeAssistantEntityState) {


### PR DESCRIPTION
Currently, "climate" is treated as "Thermostat" only.
By this, I cannot control on/off of room air conditioner using Alexa (voice).
I know I can control it by "mode" with application of Alexa.
But it is better to support not only Thermostat, but also OnOffServer, for climate, I think.

Amazon's page says:
https://developer.amazon.com/en-US/docs/alexa/smarthome/matter-support.html
"Required Matter cluster" of "Room air conditioner" is "On/Off, Thermostat".

Other implementation(matter.js):
https://github.com/project-chip/matter.js/blob/main/packages/node/src/devices/room-air-conditioner.ts
"room-air-conditioner" supoprts OnOffServer.

I just check my room air conditioner with my Alexa (including voice control).