### PR TITLE
Fix documentation

### DIFF
--- a/packages/docs/Getting Started/Bridge Configuration.md
+++ b/packages/docs/Getting Started/Bridge Configuration.md
@@ -43,7 +43,7 @@ The `type` can be one of:
 - `domain` - the domain you want to include or exclude
 - `platform` - the integration you want to include or exclude
 - `entity_category` -
-  the [entity category](https://developers.home-assistant.io/docs/core/entity/#registry-properties) (`configuration` /
+  the [entity category](https://developers.home-assistant.io/docs/core/entity/#registry-properties) (`config` /
   `diagnostic`) you want to include or exclude
 - `label` - the slug of a label you want to include or exclude
 - `area` - the slug of an area you want to include or exclude


### PR DESCRIPTION
The correct value is `config`. If you put `configuration`, they won't be excluded