### PR TITLE
Issue #767: Advanced Filtering Rules

### DIFF
--- a/packages/backend/src/matter/bridge/matcher/matches-entity-filter.ts
+++ b/packages/backend/src/matter/bridge/matcher/matches-entity-filter.ts
@@ -10,7 +10,8 @@ export function matchesEntityFilter(
 ): string[] | undefined {
   const reasons: string[] = [];
   if (filter.include.length > 0) {
-    if (!filter.include.some((matcher) => {
+    var matchingFunc = filter.exclusive ? filter.include.every : filter.include.some;
+    if (!matchingFunc((matcher) => {
       var results: boolean = testMatcher(entity, matcher);
       return matcher.invert ? !results : results;
     })) {
@@ -19,7 +20,14 @@ export function matchesEntityFilter(
   }
   if (filter.exclude.length > 0) {
     const exclusions = filter.exclude
-      .map((matcher, idx) => (testMatcher(entity, matcher) ? idx : undefined))
+      .map((matcher, idx) => {
+        var results: boolean = testMatcher(entity, matcher);
+        if (matcher.invert) {
+          return results ? undefined : idx;
+        } else {
+          return results ? idx : undefined;
+        }
+      })
       .filter((idx) => idx !== undefined);
     if (exclusions.length) {
       exclusions

--- a/packages/common/src/home-assistant-filter.ts
+++ b/packages/common/src/home-assistant-filter.ts
@@ -14,6 +14,7 @@ export interface HomeAssistantMatcher {
 }
 
 export interface HomeAssistantFilter {
+  exclusive: boolean;
   include: HomeAssistantMatcher[];
   exclude: HomeAssistantMatcher[];
 }

--- a/packages/common/src/schemas/bridge-config-schema.ts
+++ b/packages/common/src/schemas/bridge-config-schema.ts
@@ -29,6 +29,11 @@ const homeAssistantFilterSchema: JSONSchema7 = {
   title: "Include or exclude entities",
   type: "object",
   properties: {
+    exclusive: {
+      title: "Exclusive Include",
+      type: "boolean",
+      default: false,
+    },
     include: {
       title: "Include",
       type: "array",

--- a/packages/frontend/src/pages/edit-bridge/CreateBridgePage.tsx
+++ b/packages/frontend/src/pages/edit-bridge/CreateBridgePage.tsx
@@ -17,6 +17,7 @@ const defaultConfig: Omit<BridgeConfig, "port"> = {
   name: "",
   featureFlags: {},
   filter: {
+    exclusive: false,
     include: [],
     exclude: [],
   },


### PR DESCRIPTION
Adds some advanced filtering rules. Specifically:

- **Rule Inversion**: A boolean applied to each rule that, when checked, signifies to not match the rule.
- **Exclusive Filtering**: A boolean applies to an entire ruleset that, when checked, ensures that each item must pass all rules, not just a single one.
