### PR TITLE
Do not interpret "unknown" boolean HASS states as "true" matter state

### DIFF
--- a/packages/backend/src/matter/behaviors/home-assistant-entity-behavior.ts
+++ b/packages/backend/src/matter/behaviors/home-assistant-entity-behavior.ts
@@ -38,7 +38,7 @@ export class HomeAssistantEntityBehavior extends Behavior {
   }
 
   get isAvailable(): boolean {
-    return this.entity.state.state !== "unavailable";
+    return this.entity.state.state !== "unavailable" && this.entity.state.state !== "unknown";
   }
 
   callAction(action: HomeAssistantAction) {

--- a/packages/backend/src/matter/behaviors/home-assistant-entity-behavior.ts
+++ b/packages/backend/src/matter/behaviors/home-assistant-entity-behavior.ts
@@ -38,7 +38,10 @@ export class HomeAssistantEntityBehavior extends Behavior {
   }
 
   get isAvailable(): boolean {
-    return this.entity.state.state !== "unavailable" && this.entity.state.state !== "unknown";
+    return (
+      this.entity.state.state !== "unavailable" &&
+      this.entity.state.state !== "unknown"
+    );
   }
 
   callAction(action: HomeAssistantAction) {

--- a/packages/backend/src/matter/behaviors/occupancy-sensing-server.ts
+++ b/packages/backend/src/matter/behaviors/occupancy-sensing-server.ts
@@ -28,6 +28,6 @@ export class OccupancySensingServer extends Base {
   }
 
   private isOccupied(state: HomeAssistantEntityState): boolean {
-    return state.state !== "off";
+    return this.agent.get(HomeAssistantEntityBehavior).isAvailable && state.state !== "off";
   }
 }

--- a/packages/backend/src/matter/behaviors/occupancy-sensing-server.ts
+++ b/packages/backend/src/matter/behaviors/occupancy-sensing-server.ts
@@ -28,6 +28,9 @@ export class OccupancySensingServer extends Base {
   }
 
   private isOccupied(state: HomeAssistantEntityState): boolean {
-    return this.agent.get(HomeAssistantEntityBehavior).isAvailable && state.state !== "off";
+    return (
+      this.agent.get(HomeAssistantEntityBehavior).isAvailable &&
+      state.state !== "off"
+    );
   }
 }


### PR DESCRIPTION
I'm using boolean entities in Home Assistant exposed by HAMH to trigger Alexa routines, so that I can integrate with Alexa completely locally. For example, I have an helper entity that is switched to true for a few second when someone rings my doorbell. An Alexa routine then plays a doorbell sound on all of my Alexa devices. 

But I noticed that the doorbell sound is played when I restart Home Assistant. I found the issue that the sensor is in "unknown" state for a short period of time after the HASS restart. The current HAMH logic interprets this unknown state as "on"/"true".

This PR extends the "isAvailable" logic to respect both "unavailable" and "unknown" states and integrates the guard in the occupancy-sensing-server, as it was missing there.