### PR TITLE
fix: avoid transaction locks in applyPatchState by assigning each key

### DIFF
--- a/packages/backend/src/utils/apply-patch-state.test.ts
+++ b/packages/backend/src/utils/apply-patch-state.test.ts
@@ -128,4 +128,51 @@ describe("applyPatchState", () => {
     expect(patch).toEqual({ a: 0, b: 0, d: 0 });
     expect(state).toEqual({ a: 0, b: 0, c: 0, d: 0 });
   });
+
+  it("should handle rapid sequential updates without errors", () => {
+    let updateCount = 0;
+
+    // Simulate many rapid state changes
+    for (let i = 0; i < 1000; i++) {
+      const patch = applyPatchState(state, {
+        health: i % 2 === 0 ? 90 : 95,
+        name: i % 2 === 0 ? "knight" : "awesome knight",
+        weapons: i % 3 === 0 ? ["bow"] : ["axe", "sword"],
+      });
+      if (Object.keys(patch).length > 0) {
+        updateCount++;
+      }
+    }
+
+    expect(state.health).toBe(95);
+    expect(state.name).toBe("awesome knight");
+    expect(state.weapons).toEqual(["bow"]);
+    expect(updateCount).toBeGreaterThan(0);
+  });
+
+  it("should work correctly with objects that have property setters", () => {
+    let setterCallCount = 0;
+    const stateWithSetters = {
+      _value: 0,
+      get value() {
+        return this._value;
+      },
+      set value(v: number) {
+        setterCallCount++;
+        this._value = v;
+      },
+      normalProp: "test",
+    };
+
+    const patch = applyPatchState(stateWithSetters, {
+      value: 42,
+      normalProp: "updated",
+    });
+
+    // Setter should be invoked by property assignment
+    expect(setterCallCount).toBe(1);
+    expect(stateWithSetters.value).toBe(42);
+    expect(stateWithSetters.normalProp).toBe("updated");
+    expect(patch).toEqual({ value: 42, normalProp: "updated" });
+  });
 });


### PR DESCRIPTION
**Problem:**
Using `Object.assign()` to update Matter.js cluster state causes transaction deadlocks when multiple properties need to be updated. Matter.js acquires a separate lock for each property, and attempting to acquire multiple locks synchronously can lead to `SynchronousTransactionConflictError` and crashes.

**Solution:**
Changed from `Object.assign(state, patch)` to iterating through properties and assigning them individually:
```typescript
for (const key in actualPatch) {
  state[key] = actualPatch[key];
}
```

This fix does the following:
- Eliminates "SetStateOf is already waiting" warnings
- Prevents unhandled promise rejections (reason: 3)
- Resolves SynchronousTransactionConflictError crashes during state updates

And so it appears that this should resolve these issues; 

Fixes #865
