### PR TITLE
fix: Use Transaction.act to handle lock acquisition in applyPatchState

### DIFF
--- a/packages/backend/src/matter/behaviors/basic-information-server.ts
+++ b/packages/backend/src/matter/behaviors/basic-information-server.ts
@@ -12,13 +12,13 @@ export class BasicInformationServer extends Base {
     await super.initialize();
     const homeAssistant = await this.agent.load(HomeAssistantEntityBehavior);
     this.update(homeAssistant.entity);
-    this.reactTo(homeAssistant.onChange, this.update);
+    this.reactTo(homeAssistant.onChange, this.update, { offline: true });
   }
 
-  private update(entity: HomeAssistantEntityInformation) {
+  private async update(entity: HomeAssistantEntityInformation) {
     const { basicInformation } = this.env.get(BridgeDataProvider);
     const device = entity.deviceRegistry;
-    applyPatchState(this.state, {
+    await applyPatchState(this.state, {
       vendorId: VendorId(basicInformation.vendorId),
       vendorName:
         ellipse(32, device?.manufacturer) ??

--- a/packages/backend/src/matter/behaviors/boolean-state-server.ts
+++ b/packages/backend/src/matter/behaviors/boolean-state-server.ts
@@ -15,15 +15,15 @@ class BooleanStateServerBase extends Base {
   declare state: BooleanStateServerBase.State;
 
   override async initialize() {
-    super.initialize();
+    await super.initialize();
     const homeAssistant = await this.agent.load(HomeAssistantEntityBehavior);
     this.update(homeAssistant.entity);
-    this.reactTo(homeAssistant.onChange, this.update);
+    this.reactTo(homeAssistant.onChange, this.update, { offline: true });
   }
 
-  private update(entity: HomeAssistantEntityInformation) {
+  private async update(entity: HomeAssistantEntityInformation) {
     const newState = this.getStateValue(entity.state);
-    applyPatchState(this.state, { stateValue: newState });
+    await applyPatchState(this.state, { stateValue: newState });
   }
 
   private getStateValue(entity: HomeAssistantEntityState): boolean {

--- a/packages/backend/src/matter/behaviors/color-control-server.ts
+++ b/packages/backend/src/matter/behaviors/color-control-server.ts
@@ -31,13 +31,13 @@ export class ColorControlServerBase extends FeaturedBase {
   declare state: ColorControlServerBase.State;
 
   override async initialize() {
-    await super.initialize();
+    super.initialize();
     const homeAssistant = await this.agent.load(HomeAssistantEntityBehavior);
     this.update(homeAssistant.entity);
-    this.reactTo(homeAssistant.onChange, this.update);
+    this.reactTo(homeAssistant.onChange, this.update, { offline: true });
   }
 
-  private update(entity: HomeAssistantEntityInformation) {
+  private async update(entity: HomeAssistantEntityInformation) {
     const config = this.state.config;
     const currentKelvin = config.getCurrentKelvin(entity.state, this.agent);
     let minKelvin =
@@ -73,7 +73,7 @@ export class ColorControlServerBase extends FeaturedBase {
       currentMireds = Math.max(Math.min(currentMireds, maxMireds), minMireds);
     }
 
-    applyPatchState(this.state, {
+    await applyPatchState(this.state, {
       colorMode: this.getColorModeFromFeatures(
         config.getCurrentMode(entity.state, this.agent),
       ),

--- a/packages/backend/src/matter/behaviors/fan-control-server.ts
+++ b/packages/backend/src/matter/behaviors/fan-control-server.ts
@@ -40,7 +40,7 @@ export class FanControlServerBase extends FeaturedBase {
     super.initialize();
     const homeAssistant = await this.agent.load(HomeAssistantEntityBehavior);
     this.update(homeAssistant.entity);
-    this.reactTo(homeAssistant.onChange, this.update);
+    this.reactTo(homeAssistant.onChange, this.update, { offline: true });
     this.reactTo(
       this.events.percentSetting$Changed,
       this.targetPercentSettingChanged,
@@ -60,7 +60,7 @@ export class FanControlServerBase extends FeaturedBase {
     }
   }
 
-  private update(entity: HomeAssistantEntityInformation) {
+  private async update(entity: HomeAssistantEntityInformation) {
     const config = this.state.config;
     const percentage = config.getPercentage(entity.state, this.agent) ?? 0;
     const speedMax = Math.round(
@@ -73,7 +73,7 @@ export class FanControlServerBase extends FeaturedBase {
       ? FanMode.create(FanControl.FanMode.Auto, fanModeSequence)
       : FanMode.fromSpeedPercent(percentage, fanModeSequence);
 
-    applyPatchState(this.state, {
+    await applyPatchState(this.state, {
       percentSetting: percentage,
       percentCurrent: percentage,
       fanMode: fanMode.mode,

--- a/packages/backend/src/matter/behaviors/humidity-measurement-server.ts
+++ b/packages/backend/src/matter/behaviors/humidity-measurement-server.ts
@@ -16,15 +16,15 @@ class HumidityMeasurementServerBase extends Base {
   declare state: HumidityMeasurementServerBase.State;
 
   override async initialize() {
-    await super.initialize();
+    super.initialize();
     const homeAssistant = await this.agent.load(HomeAssistantEntityBehavior);
     this.update(homeAssistant.entity);
-    this.reactTo(homeAssistant.onChange, this.update);
+    this.reactTo(homeAssistant.onChange, this.update, { offline: true });
   }
 
-  private update(entity: HomeAssistantEntityInformation) {
+  private async update(entity: HomeAssistantEntityInformation) {
     const humidity = this.getHumidity(this.state.config, entity.state);
-    applyPatchState(this.state, { measuredValue: humidity });
+    await applyPatchState(this.state, { measuredValue: humidity });
   }
 
   private getHumidity(

--- a/packages/backend/src/matter/behaviors/illuminance-measurement-server.ts
+++ b/packages/backend/src/matter/behaviors/illuminance-measurement-server.ts
@@ -16,15 +16,15 @@ class IlluminanceMeasurementServerBase extends Base {
   declare state: IlluminanceMeasurementServerBase.State;
 
   override async initialize() {
-    await super.initialize();
+    super.initialize();
     const homeAssistant = await this.agent.load(HomeAssistantEntityBehavior);
     this.update(homeAssistant.entity);
-    this.reactTo(homeAssistant.onChange, this.update);
+    this.reactTo(homeAssistant.onChange, this.update, { offline: true });
   }
 
-  private update(entity: HomeAssistantEntityInformation) {
+  private async update(entity: HomeAssistantEntityInformation) {
     const illuminance = this.getIlluminance(this.state.config, entity.state);
-    applyPatchState(this.state, { measuredValue: illuminance });
+    await applyPatchState(this.state, { measuredValue: illuminance });
   }
 
   private getIlluminance(

--- a/packages/backend/src/matter/behaviors/level-control-server.ts
+++ b/packages/backend/src/matter/behaviors/level-control-server.ts
@@ -17,13 +17,13 @@ export class LevelControlServerBase extends FeaturedBase {
   declare state: LevelControlServerBase.State;
 
   override async initialize() {
-    super.initialize();
+    await super.initialize();
     const homeAssistant = await this.agent.load(HomeAssistantEntityBehavior);
     this.update(homeAssistant.entity);
-    this.reactTo(homeAssistant.onChange, this.update);
+    this.reactTo(homeAssistant.onChange, this.update, { offline: true });
   }
 
-  private update({ state }: HomeAssistantEntityInformation) {
+  private async update({ state }: HomeAssistantEntityInformation) {
     const config = this.state.config;
 
     const minLevel = 1;
@@ -40,7 +40,7 @@ export class LevelControlServerBase extends FeaturedBase {
       currentLevel = Math.min(Math.max(minLevel, currentLevel), maxLevel);
     }
 
-    applyPatchState(this.state, {
+    await applyPatchState(this.state, {
       minLevel: minLevel,
       maxLevel: maxLevel,
       currentLevel: currentLevel,

--- a/packages/backend/src/matter/behaviors/lock-server.ts
+++ b/packages/backend/src/matter/behaviors/lock-server.ts
@@ -21,11 +21,11 @@ class LockServerBase extends Base {
     await super.initialize();
     const homeAssistant = await this.agent.load(HomeAssistantEntityBehavior);
     this.update(homeAssistant.entity);
-    this.reactTo(homeAssistant.onChange, this.update);
+    this.reactTo(homeAssistant.onChange, this.update, { offline: true });
   }
 
-  private update(entity: HomeAssistantEntityInformation) {
-    applyPatchState(this.state, {
+  private async update(entity: HomeAssistantEntityInformation) {
+    await applyPatchState(this.state, {
       lockState: this.state.config.getLockState(entity.state, this.agent),
       lockType: DoorLock.LockType.DeadBolt,
       operatingMode: DoorLock.OperatingMode.Normal,

--- a/packages/backend/src/matter/behaviors/media-input-server.ts
+++ b/packages/backend/src/matter/behaviors/media-input-server.ts
@@ -19,11 +19,11 @@ class MediaInputServerBase extends Base {
   override async initialize() {
     super.initialize();
     const homeAssistant = await this.agent.load(HomeAssistantEntityBehavior);
-    this.reactTo(homeAssistant.onChange, this.update);
+    this.reactTo(homeAssistant.onChange, this.update, { offline: true });
     this.update(homeAssistant.entity);
   }
 
-  private update(entity: HomeAssistantEntityInformation) {
+  private async update(entity: HomeAssistantEntityInformation) {
     const config = this.state.config;
     let source_idx = 0;
     const sourceList = config.getSourceList(entity.state, this.agent)?.sort();
@@ -38,7 +38,7 @@ class MediaInputServerBase extends Base {
     if (currentInput === -1 || currentInput == null) {
       currentInput = 0;
     }
-    applyPatchState(this.state, {
+    await applyPatchState(this.state, {
       inputList,
       currentInput,
     });

--- a/packages/backend/src/matter/behaviors/occupancy-sensing-server.ts
+++ b/packages/backend/src/matter/behaviors/occupancy-sensing-server.ts
@@ -12,11 +12,11 @@ export class OccupancySensingServer extends Base {
     await super.initialize();
     const homeAssistant = await this.agent.load(HomeAssistantEntityBehavior);
     this.update(homeAssistant.entity);
-    this.reactTo(homeAssistant.onChange, this.update);
+    this.reactTo(homeAssistant.onChange, this.update, { offline: true });
   }
 
-  private update({ state }: HomeAssistantEntityInformation) {
-    applyPatchState(this.state, {
+  private async update({ state }: HomeAssistantEntityInformation) {
+    await applyPatchState(this.state, {
       occupancy: { occupied: this.isOccupied(state) },
       occupancySensorType: OccupancySensing.OccupancySensorType.PhysicalContact,
       occupancySensorTypeBitmap: {

--- a/packages/backend/src/matter/behaviors/on-off-server.ts
+++ b/packages/backend/src/matter/behaviors/on-off-server.ts
@@ -25,11 +25,11 @@ class OnOffServerBase extends FeaturedBase {
     super.initialize();
     const homeAssistant = await this.agent.load(HomeAssistantEntityBehavior);
     this.update(homeAssistant.entity);
-    this.reactTo(homeAssistant.onChange, this.update);
+    this.reactTo(homeAssistant.onChange, this.update, { offline: true });
   }
 
-  protected update({ state }: HomeAssistantEntityInformation) {
-    applyPatchState(this.state, {
+  protected async update({ state }: HomeAssistantEntityInformation) {
+    await applyPatchState(this.state, {
       onOff: this.isOn(state),
     });
   }

--- a/packages/backend/src/matter/behaviors/rvc-operational-state-server.ts
+++ b/packages/backend/src/matter/behaviors/rvc-operational-state-server.ts
@@ -21,11 +21,11 @@ class RvcOperationalStateServerBase extends Base {
   override async initialize() {
     const homeAssistant = await this.agent.load(HomeAssistantEntityBehavior);
     this.update(homeAssistant.entity);
-    this.reactTo(homeAssistant.onChange, this.update);
+    this.reactTo(homeAssistant.onChange, this.update, { offline: true });
     await super.initialize();
   }
 
-  private update(entity: HomeAssistantEntityInformation) {
+  private async update(entity: HomeAssistantEntityInformation) {
     const operationalState = this.state.config.getOperationalState(
       entity.state,
       this.agent,
@@ -36,7 +36,7 @@ class RvcOperationalStateServerBase extends Base {
         operationalStateId: id,
       }));
 
-    applyPatchState(this.state, {
+    await applyPatchState(this.state, {
       operationalState,
       operationalStateList,
       operationalError: {

--- a/packages/backend/src/matter/behaviors/rvc-run-mode-server.ts
+++ b/packages/backend/src/matter/behaviors/rvc-run-mode-server.ts
@@ -27,12 +27,12 @@ class RvcRunModeServerBase extends Base {
   override async initialize() {
     const homeAssistant = await this.agent.load(HomeAssistantEntityBehavior);
     this.update(homeAssistant.entity);
-    this.reactTo(homeAssistant.onChange, this.update);
+    this.reactTo(homeAssistant.onChange, this.update, { offline: true });
     await super.initialize();
   }
 
-  private update(entity: HomeAssistantEntityInformation) {
-    applyPatchState(this.state, {
+  private async update(entity: HomeAssistantEntityInformation) {
+    await applyPatchState(this.state, {
       currentMode: this.state.config.getCurrentMode(entity.state, this.agent),
       supportedModes: this.state.config.getSupportedModes(
         entity.state,

--- a/packages/backend/src/matter/behaviors/temperature-measurement-server.ts
+++ b/packages/backend/src/matter/behaviors/temperature-measurement-server.ts
@@ -20,11 +20,11 @@ class TemperatureMeasurementServerBase extends Base {
     await super.initialize();
     const homeAssistant = await this.agent.load(HomeAssistantEntityBehavior);
     this.update(homeAssistant.entity);
-    this.reactTo(homeAssistant.onChange, this.update);
+    this.reactTo(homeAssistant.onChange, this.update, { offline: true });
   }
 
-  private update(entity: HomeAssistantEntityInformation) {
-    applyPatchState(this.state, {
+  private async update(entity: HomeAssistantEntityInformation) {
+    await applyPatchState(this.state, {
       measuredValue: this.getTemperature(entity.state) ?? null,
     });
   }

--- a/packages/backend/src/matter/behaviors/thermostat-server.ts
+++ b/packages/backend/src/matter/behaviors/thermostat-server.ts
@@ -67,10 +67,10 @@ export class ThermostatServerBase extends FeaturedBase {
         this.heatingSetpointChanged,
       );
     }
-    this.reactTo(homeAssistant.onChange, this.update);
+    this.reactTo(homeAssistant.onChange, this.update, { offline: true });
   }
 
-  private update(entity: HomeAssistantEntityInformation) {
+  private async update(entity: HomeAssistantEntityInformation) {
     const config = this.state.config;
     const minSetpointLimit = config
       .getMinTemperature(entity.state, this.agent)
@@ -93,7 +93,7 @@ export class ThermostatServerBase extends FeaturedBase {
     const systemMode = this.getSystemMode(entity);
     const runningMode = config.getRunningMode(entity.state, this.agent);
 
-    applyPatchState(this.state, {
+    await applyPatchState(this.state, {
       localTemperature: localTemperature,
       systemMode: systemMode,
       thermostatRunningState: this.getRunningState(systemMode, runningMode),

--- a/packages/backend/src/matter/behaviors/window-covering-server.ts
+++ b/packages/backend/src/matter/behaviors/window-covering-server.ts
@@ -59,10 +59,10 @@ export class WindowCoveringServerBase extends FeaturedBase {
     await super.initialize();
     const homeAssistant = await this.agent.load(HomeAssistantEntityBehavior);
     this.update(homeAssistant.entity);
-    this.reactTo(homeAssistant.onChange, this.update);
+    this.reactTo(homeAssistant.onChange, this.update, { offline: true });
   }
 
-  private update(entity: HomeAssistantEntityInformation) {
+  private async update(entity: HomeAssistantEntityInformation) {
     const config = this.state.config;
     const state = entity.state as HomeAssistantEntityState;
     const movementStatus = config.getMovementStatus(state, this.agent);
@@ -83,7 +83,7 @@ export class WindowCoveringServerBase extends FeaturedBase {
     );
     const currentTilt100ths = currentTilt ? currentTilt * 100 : null;
 
-    applyPatchState<WindowCoveringServerBase.State>(this.state, {
+    await applyPatchState<WindowCoveringServerBase.State>(this.state, {
       type:
         this.features.lift && this.features.tilt
           ? WindowCovering.WindowCoveringType.TiltBlindLift

--- a/packages/backend/src/utils/apply-patch-state.test.ts
+++ b/packages/backend/src/utils/apply-patch-state.test.ts
@@ -27,8 +27,8 @@ describe("applyPatchState", () => {
     };
   });
 
-  it("should only not patch unchanged properties", () => {
-    const actualPatch = applyPatchState(state, {
+  it("should only not patch unchanged properties", async () => {
+    const actualPatch = await applyPatchState(state, {
       health: 95,
       name: "awesome knight",
       weapons: ["axe", "sword"],
@@ -51,8 +51,8 @@ describe("applyPatchState", () => {
     });
   });
 
-  it("should patch changed properties", () => {
-    const actualPatch = applyPatchState(state, {
+  it("should patch changed properties", async () => {
+    const actualPatch = await applyPatchState(state, {
       health: 90,
       name: "ultra knight",
       weapons: ["bow", "axe"],
@@ -84,8 +84,8 @@ describe("applyPatchState", () => {
     });
   });
 
-  it("should patch a state partially", () => {
-    const actualPatch = applyPatchState(state, {
+  it("should patch a state partially", async () => {
+    const actualPatch = await applyPatchState(state, {
       name: "awesome knight",
       weapons: ["bow", "axe"],
       additionalAttributes: {
@@ -114,7 +114,7 @@ describe("applyPatchState", () => {
     });
   });
 
-  it("should ignore undefined and not mess with zero and null", () => {
+  it("should ignore undefined and not mess with zero and null", async () => {
     const state: Record<
       "a" | "b" | "c" | "d",
       string | number | undefined | null
@@ -124,17 +124,22 @@ describe("applyPatchState", () => {
       c: 0,
       d: "",
     };
-    const patch = applyPatchState(state, { a: 0, b: 0, c: undefined, d: 0 });
+    const patch = await applyPatchState(state, {
+      a: 0,
+      b: 0,
+      c: undefined,
+      d: 0,
+    });
     expect(patch).toEqual({ a: 0, b: 0, d: 0 });
     expect(state).toEqual({ a: 0, b: 0, c: 0, d: 0 });
   });
 
-  it("should handle rapid sequential updates without errors", () => {
+  it("should handle rapid sequential updates without errors", async () => {
     let updateCount = 0;
 
     // Simulate many rapid state changes
     for (let i = 0; i < 1000; i++) {
-      const patch = applyPatchState(state, {
+      const patch = await applyPatchState(state, {
         health: i % 2 === 0 ? 90 : 95,
         name: i % 2 === 0 ? "knight" : "awesome knight",
         weapons: i % 3 === 0 ? ["bow"] : ["axe", "sword"],
@@ -150,7 +155,7 @@ describe("applyPatchState", () => {
     expect(updateCount).toBeGreaterThan(0);
   });
 
-  it("should work correctly with objects that have property setters", () => {
+  it("should work correctly with objects that have property setters", async () => {
     let setterCallCount = 0;
     const stateWithSetters = {
       _value: 0,
@@ -164,7 +169,7 @@ describe("applyPatchState", () => {
       normalProp: "test",
     };
 
-    const patch = applyPatchState(stateWithSetters, {
+    const patch = await applyPatchState(stateWithSetters, {
       value: 42,
       normalProp: "updated",
     });

--- a/packages/backend/src/utils/apply-patch-state.ts
+++ b/packages/backend/src/utils/apply-patch-state.ts
@@ -1,7 +1,23 @@
-export function applyPatchState<T extends object>(
+import { Transaction } from "@matter/general";
+
+/**
+ * Safely applies a patch to state, handling transaction contexts properly.
+ *
+ * Wraps the state update in Transaction.act() to properly acquire locks
+ * asynchronously, avoiding "synchronous-transaction-conflict" errors when
+ * called from within reactors or other transaction contexts.
+ */
+export async function applyPatchState<T extends object>(
   state: T,
   patch: Partial<T>,
-): Partial<T> {
+): Promise<Partial<T>> {
+  // Use Transaction.act to properly handle lock acquisition
+  return await Transaction.act("applyPatchState", async () => {
+    return applyPatch(state, patch);
+  });
+}
+
+function applyPatch<T extends object>(state: T, patch: Partial<T>): Partial<T> {
   // Only include values that need to be changed
   const actualPatch: Partial<T> = {};
 


### PR DESCRIPTION
This PR fixes a crash that occurred when Matter.js behavior reactors were triggered within an active state update transaction.

This crash was introduced following the refactoring in #869.

The sequence of events leading to the crash:
- A state update (e.g., via setStateOf) starts a transaction and acquires necessary locks.
- Behavior reactors (like onOff.update) are triggered within that transaction context.
- The reactor synchronously calls applyPatchState, which attempts to acquire the same lock synchronously, resulting in the fatal error: [synchronous-transaction-conflict].

Matter.js strictly disallows a synchronous attempt to re-acquire a lock that is already held by an ancestor transaction.

The fix is to convert applyPatchState to an async function and wrap its core logic with await Transaction.act(...). As reactors are the main consumers of this function, I have updated all the behavior files to use await applyPatchState(...) and made their update() methods asynchronous, including using the offline option to specify that it has its own transaction context.

I've given this a rip on my Home Assistant instance and it seems solid from my testing.

Please consider ensuring this gets merged prior to your next release since it is related to #869. Both modifications are necessary as far as I can tell.