### PR TITLE
fix: crash in level control server

### DIFF
--- a/packages/backend/src/matter/behaviors/level-control-server.ts
+++ b/packages/backend/src/matter/behaviors/level-control-server.ts
@@ -23,6 +23,13 @@ export class LevelControlServerBase extends FeaturedBase {
     this.reactTo(homeAssistant.onChange, this.update, { offline: true });
   }
 
+  // Override Matter.js's handleOnOffChange to prevent synchronous transaction conflicts
+  // The base implementation tries to update currentLevel synchronously when onOff changes
+  override handleOnOffChange(_onOff: boolean) {
+    // Do nothing - we handle level updates via our own update() method
+    // This prevents the base class from causing synchronous lock conflicts
+  }
+
   private async update({ state }: HomeAssistantEntityInformation) {
     const config = this.state.config;
 


### PR DESCRIPTION
Matter.js's built-in LevelControlServer.handleOnOffChange() reactor tried to update the currentLevel state synchronously while already inside a transaction, causing a "Cannot lock ... synchronously" error.

The crash was caused by Matter.js's built-in
LevelControlServer.handleOnOffChange() reactor, which:

- Fires when the onOff state changes
- Tries to update currentLevel synchronously
- Causes a "synchronous-transaction-conflict" error when our async offline reactors are running

The fix: Override handleOnOffChange() to do nothing, since we already handle level updates through our own update() method that listens to Home Assistant state changes. This prevents Matter.js's built-in synchronous reactor from interfering.

This is essentially working around a limitation in Matter.js where their base behavior reactors don't support the offline option that we need for async operations.

@t0bst4r I have tested this out in a local HA instance of mine.

Fixes https://github.com/t0bst4r/home-assistant-matter-hub/issues/876