### PR TITLE
Cover open state (position 0) incorrectly syncs as `null` instead of 0% in Matter.

### DIFF
--- a/packages/backend/src/matter/behaviors/window-covering-server.ts
+++ b/packages/backend/src/matter/behaviors/window-covering-server.ts
@@ -76,11 +76,11 @@ export class WindowCoveringServerBase extends FeaturedBase {
     const currentLift = normalize(
       config.getCurrentLiftPosition(state, this.agent),
     );
-    const currentLift100ths = currentLift ? currentLift * 100 : null;
+    const currentLift100ths = currentLift != null ? currentLift * 100 : null;
     const currentTilt = normalize(
       config.getCurrentTiltPosition(state, this.agent),
     );
-    const currentTilt100ths = currentTilt ? currentTilt * 100 : null;
+    const currentTilt100ths = currentTilt != null ? currentTilt * 100 : null;
 
     applyPatchState<WindowCoveringServerBase.State>(this.state, {
       type:


### PR DESCRIPTION
currentLift100ths and currentTilt100ths were always set to "null" instead of 0.

Binary covers with position 0 now reports correctly
