### PR TITLE
Fix garage door binary covers have inverted position

### DIFF
--- a/packages/backend/src/matter/endpoints/legacy/cover/behaviors/cover-window-covering-server.ts
+++ b/packages/backend/src/matter/endpoints/legacy/cover/behaviors/cover-window-covering-server.ts
@@ -31,12 +31,23 @@ const config: WindowCoveringConfig = {
     let position = attributes(entity).current_position;
     if (position == null) {
       const coverState = entity.state as CoverDeviceState;
-      position =
-        coverState === CoverDeviceState.closed
-          ? 100
-          : coverState === CoverDeviceState.open
+
+      const isGarage = (attributes(entity) as any).device_class === "garage";
+      if (isGarage) {
+        position =
+          coverState === CoverDeviceState.closed
             ? 0
-            : undefined;
+            : coverState === CoverDeviceState.open
+              ? 100
+              : undefined;
+      } else {
+        position =
+          coverState === CoverDeviceState.closed
+            ? 100
+            : coverState === CoverDeviceState.open
+              ? 0
+              : undefined;
+      }
     }
     return position == null ? null : adjustPosition(position, agent);
   },

--- a/packages/common/src/domains/cover.ts
+++ b/packages/common/src/domains/cover.ts
@@ -8,6 +8,7 @@ export interface CoverDeviceAttributes {
   current_position?: number;
   current_tilt_position?: number;
   supported_features?: number;
+  device_class?: string;
 }
 
 export const CoverSupportedFeatures = {


### PR DESCRIPTION
New PR, I've simplified everything, I prefer to resubmit a new one. 

It seems position % needs to be inverted for garage door cover type
fix #371 #431

Tested ok on Google Home,

A simple Garage door cover template in HA currently display as inverted on Google Home  :
Is it not the same on Alexa ? 

```
cover:
  - platform: template
    covers:
      garage_door:
        unique_id: garage_door_1
        device_class: garage
        friendly_name: "Garage Door"
        value_template: >
          {% if is_state('binary_sensor.garage_door_contact', 'on') %}
            open
          {% else %}
            closed
          {% endif %}
        open_cover:
          action: switch.turn_on
          target:
              entity_id: switch.garage_door_trigger
        close_cover:
          action: switch.turn_off
          target:
              entity_id: switch.porte_garage_trigger
        stop_cover:
          service: switch.turn_on
          entity_id: switch.garage_door_trigger
```
 