### PR TITLE
Set currentLevel in levelControl to 100% when light is off

### DIFF
--- a/packages/backend/src/matter/endpoints/legacy/light/behaviors/light-level-control-server.ts
+++ b/packages/backend/src/matter/endpoints/legacy/light/behaviors/light-level-control-server.ts
@@ -13,7 +13,7 @@ const config: LevelControlConfig = {
     if (brightness) {
       return brightness / 255;
     }
-    return null;
+    return 100.0;
   },
   moveToLevelPercent: (brightnessPercent) => ({
     action: "light.turn_on",


### PR DESCRIPTION
Propose setting the level to 100 % to solve both issue #740 (light is not responding in Apple Home when level is null) and #880 (Alexa sets light to 100 % when turning it on again if level was 0 %).